### PR TITLE
feat(table): Generalize icon component for all icon types

### DIFF
--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -460,8 +460,7 @@ defmodule Cinder.Table.LiveComponent do
     """
   end
 
-  # Simple heroicon component
-  defp icon(%{name: "hero-" <> _} = assigns) do
+  defp icon(%{name: _, class: _} = assigns) do
     ~H"""
     <span class={[@name, @class]} />
     """


### PR DESCRIPTION
This PR removes the hero-specific pattern match in icon component, allowing it to handle any icon name with a class.

Projects that use other web fonts for icons (such as fontawesome) cannot have custom sort icons because the included `<.icon />` component pattern match on `hero` being part of the icon name. By removing the pattern matching, users are able to pass in any icon name to the component making it easier to build custom styles.

```elixir
defmodule MyCinderTheme do 
  component Cinder.Components.Sorting do
    set :sort_asc_icon_name, "fa-solid fa-chevron-up"
    set :sort_desc_icon_name, "fa-solid fa-chevron-down"
    set :sort_none_icon_name, "fa-solid fa-chevron-down"
  end
end
```