### PR TITLE
fix: Render messages passed to table

### DIFF
--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -89,7 +89,7 @@ defmodule Cinder.Table.LiveComponent do
             </tr>
             <tr :if={@data == [] and not @loading}>
               <td colspan={length(@columns)} class={@theme.empty_class} {@theme.empty_data}>
-                No results found
+                {@empty_message}
               </td>
             </tr>
           </tbody>
@@ -103,7 +103,7 @@ defmodule Cinder.Table.LiveComponent do
             <circle class={@theme.loading_spinner_circle_class} {@theme.loading_spinner_circle_data} cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class={@theme.loading_spinner_path_class} {@theme.loading_spinner_path_data} fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
-          Loading...
+          {@loading_message}
         </div>
       </div>
 


### PR DESCRIPTION
A humble suggestion for fixing the issue where messages for no results and loading respectively are not rendered since they are hard coded.

fixes: #24