### PR TITLE
Extend customizability of table component

### DIFF
--- a/lib/cinder/filter_manager.ex
+++ b/lib/cinder/filter_manager.ex
@@ -41,9 +41,6 @@ defmodule Cinder.FilterManager do
   - `filters` - Current filter state map
   - `theme` - Theme configuration
   - `target` - LiveComponent target for events
-  - `filters_label` - Custom label for the filter controls
-  - `active_label` - Custom label for the filter controls
-  - `clear_all_label` - Custom label for clear all button
 
   ## Returns
   HEEx template for filter controls
@@ -63,9 +60,9 @@ defmodule Cinder.FilterManager do
     <div :if={@filterable_columns != []} class={@theme.filter_container_class} {@theme.filter_container_data}>
       <div class={@theme.filter_header_class} {@theme.filter_header_data}>
         <span class={@theme.filter_title_class} {@theme.filter_title_data}>
-          {@filters_label}
+          🔍 Filters
           <span class={[@theme.filter_count_class, if(@active_filters == 0, do: "invisible", else: "")]} {@theme.filter_count_data}>
-            ({@active_filters} {@active_label})
+            ({@active_filters} active)
           </span>
         </span>
         <button
@@ -74,7 +71,7 @@ defmodule Cinder.FilterManager do
           class={[@theme.filter_clear_all_class, if(@active_filters == 0, do: "invisible", else: "")]}
           {@theme.filter_clear_all_data}
         >
-          {@clear_all_label}
+          Clear All
         </button>
       </div>
 

--- a/lib/cinder/filter_manager.ex
+++ b/lib/cinder/filter_manager.ex
@@ -41,6 +41,9 @@ defmodule Cinder.FilterManager do
   - `filters` - Current filter state map
   - `theme` - Theme configuration
   - `target` - LiveComponent target for events
+  - `filters_label` - Custom label for the filter controls
+  - `active_label` - Custom label for the filter controls
+  - `clear_all_label` - Custom label for clear all button
 
   ## Returns
   HEEx template for filter controls
@@ -60,9 +63,9 @@ defmodule Cinder.FilterManager do
     <div :if={@filterable_columns != []} class={@theme.filter_container_class} {@theme.filter_container_data}>
       <div class={@theme.filter_header_class} {@theme.filter_header_data}>
         <span class={@theme.filter_title_class} {@theme.filter_title_data}>
-          🔍 Filters
+          {@filters_label}
           <span class={[@theme.filter_count_class, if(@active_filters == 0, do: "invisible", else: "")]} {@theme.filter_count_data}>
-            ({@active_filters} active)
+            ({@active_filters} {@active_label})
           </span>
         </span>
         <button
@@ -71,7 +74,7 @@ defmodule Cinder.FilterManager do
           class={[@theme.filter_clear_all_class, if(@active_filters == 0, do: "invisible", else: "")]}
           {@theme.filter_clear_all_data}
         >
-          Clear All
+          {@clear_all_label}
         </button>
       </div>
 

--- a/lib/cinder/filter_manager.ex
+++ b/lib/cinder/filter_manager.ex
@@ -60,7 +60,7 @@ defmodule Cinder.FilterManager do
     <div :if={@filterable_columns != []} class={@theme.filter_container_class} {@theme.filter_container_data}>
       <div class={@theme.filter_header_class} {@theme.filter_header_data}>
         <span class={@theme.filter_title_class} {@theme.filter_title_data}>
-          🔍 Filters
+          {@filters_label}
           <span class={[@theme.filter_count_class, if(@active_filters == 0, do: "invisible", else: "")]} {@theme.filter_count_data}>
             ({@active_filters} active)
           </span>

--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -186,13 +186,7 @@ defmodule Cinder.Table do
   - `show_filters` - Show filter controls (default: auto-detect from columns)
   - `show_pagination` - Show pagination controls (default: true)
   - `loading_message` - Custom loading message
-  - `clear_all_label` - Custom label for the clear all button (default: "Clear all")
-  - `filters_label` - Custom label for filtering (default: "🔍 Filters")
-  - `active_label` - Custom label for active filters indicator (default: "active")
-  - `page_label`- Custom label for the pagination controls (default: "Page")
-  - `of_label`- Custom label for the pagination controls (default: "of")
-  - `showing_label`- Custom label for the pagination controls (default: "showing")
-  - `empty_message` - Custom empty state message (default: "No results found")
+  - `empty_message` - Custom empty state message
   - `class` - Additional CSS classes
 
   ## When to Use Resource vs Query
@@ -294,36 +288,6 @@ defmodule Cinder.Table do
 
   attr(:loading_message, :string, default: "Loading...", doc: "Message to show while loading")
 
-  attr(:clear_all_label, :string,
-    default: "Clear all",
-    doc: "Label on the button to clear all filters"
-  )
-
-  attr(:filters_label, :string,
-    default: "🔍 Filters",
-    doc: "Label for the filters component"
-  )
-
-  attr(:active_label, :string,
-    default: "active",
-    doc: "Label for the count of active filters"
-  )
-
-  attr(:page_label, :string,
-    default: "Page",
-    doc: "Label for the \"Page\" part of the pagination controls"
-  )
-
-  attr(:of_label, :string,
-    default: "of",
-    doc: "Label for the \"of\" part of the pagination controls"
-  )
-
-  attr(:showing_label, :string,
-    default: "showing",
-    doc: "Label for the \"showing\" part of the pagination controls"
-  )
-
   attr(:empty_message, :string,
     default: "No results found",
     doc: "Message to show when no results"
@@ -366,12 +330,6 @@ defmodule Cinder.Table do
       |> assign_new(:on_state_change, fn -> nil end)
       |> assign_new(:show_pagination, fn -> true end)
       |> assign_new(:loading_message, fn -> "Loading..." end)
-      |> assign_new(:clear_all_label, fn -> "Clear all" end)
-      |> assign_new(:filters_label, fn -> "🔍 Filters" end)
-      |> assign_new(:active_label, fn -> "active" end)
-      |> assign_new(:page_label, fn -> "Page" end)
-      |> assign_new(:of_label, fn -> "of" end)
-      |> assign_new(:showing_label, fn -> "showing" end)
       |> assign_new(:empty_message, fn -> "No results found" end)
       |> assign_new(:class, fn -> "" end)
       |> assign_new(:tenant, fn -> nil end)
@@ -414,12 +372,6 @@ defmodule Cinder.Table do
         show_filters={@show_filters}
         show_pagination={@show_pagination}
         loading_message={@loading_message}
-        clear_all_label={@clear_all_label}
-        filters_label={@filters_label}
-        active_label={@active_label}
-        page_label={@page_label}
-        of_label={@of_label}
-        showing_label={@showing_label}
         empty_message={@empty_message}
         col={@processed_columns}
         row_click={@row_click}

--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -186,7 +186,13 @@ defmodule Cinder.Table do
   - `show_filters` - Show filter controls (default: auto-detect from columns)
   - `show_pagination` - Show pagination controls (default: true)
   - `loading_message` - Custom loading message
-  - `empty_message` - Custom empty state message
+  - `clear_all_label` - Custom label for the clear all button (default: "Clear all")
+  - `filters_label` - Custom label for filtering (default: "🔍 Filters")
+  - `active_label` - Custom label for active filters indicator (default: "active")
+  - `page_label`- Custom label for the pagination controls (default: "Page")
+  - `of_label`- Custom label for the pagination controls (default: "of")
+  - `showing_label`- Custom label for the pagination controls (default: "showing")
+  - `empty_message` - Custom empty state message (default: "No results found")
   - `class` - Additional CSS classes
 
   ## When to Use Resource vs Query
@@ -288,6 +294,36 @@ defmodule Cinder.Table do
 
   attr(:loading_message, :string, default: "Loading...", doc: "Message to show while loading")
 
+  attr(:clear_all_label, :string,
+    default: "Clear all",
+    doc: "Label on the button to clear all filters"
+  )
+
+  attr(:filters_label, :string,
+    default: "🔍 Filters",
+    doc: "Label for the filters component"
+  )
+
+  attr(:active_label, :string,
+    default: "active",
+    doc: "Label for the count of active filters"
+  )
+
+  attr(:page_label, :string,
+    default: "Page",
+    doc: "Label for the \"Page\" part of the pagination controls"
+  )
+
+  attr(:of_label, :string,
+    default: "of",
+    doc: "Label for the \"of\" part of the pagination controls"
+  )
+
+  attr(:showing_label, :string,
+    default: "showing",
+    doc: "Label for the \"showing\" part of the pagination controls"
+  )
+
   attr(:empty_message, :string,
     default: "No results found",
     doc: "Message to show when no results"
@@ -330,6 +366,12 @@ defmodule Cinder.Table do
       |> assign_new(:on_state_change, fn -> nil end)
       |> assign_new(:show_pagination, fn -> true end)
       |> assign_new(:loading_message, fn -> "Loading..." end)
+      |> assign_new(:clear_all_label, fn -> "Clear all" end)
+      |> assign_new(:filters_label, fn -> "🔍 Filters" end)
+      |> assign_new(:active_label, fn -> "active" end)
+      |> assign_new(:page_label, fn -> "Page" end)
+      |> assign_new(:of_label, fn -> "of" end)
+      |> assign_new(:showing_label, fn -> "showing" end)
       |> assign_new(:empty_message, fn -> "No results found" end)
       |> assign_new(:class, fn -> "" end)
       |> assign_new(:tenant, fn -> nil end)
@@ -372,6 +414,12 @@ defmodule Cinder.Table do
         show_filters={@show_filters}
         show_pagination={@show_pagination}
         loading_message={@loading_message}
+        clear_all_label={@clear_all_label}
+        filters_label={@filters_label}
+        active_label={@active_label}
+        page_label={@page_label}
+        of_label={@of_label}
+        showing_label={@showing_label}
         empty_message={@empty_message}
         col={@processed_columns}
         row_click={@row_click}

--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -186,6 +186,7 @@ defmodule Cinder.Table do
   - `show_filters` - Show filter controls (default: auto-detect from columns)
   - `show_pagination` - Show pagination controls (default: true)
   - `loading_message` - Custom loading message
+  - `filters_label` - Custom label for filtering (default: "🔍 Filters")
   - `empty_message` - Custom empty state message
   - `class` - Additional CSS classes
 
@@ -288,6 +289,11 @@ defmodule Cinder.Table do
 
   attr(:loading_message, :string, default: "Loading...", doc: "Message to show while loading")
 
+  attr(:filters_label, :string,
+    default: "🔍 Filters",
+    doc: "Label for the filters component"
+  )
+
   attr(:empty_message, :string,
     default: "No results found",
     doc: "Message to show when no results"
@@ -330,6 +336,7 @@ defmodule Cinder.Table do
       |> assign_new(:on_state_change, fn -> nil end)
       |> assign_new(:show_pagination, fn -> true end)
       |> assign_new(:loading_message, fn -> "Loading..." end)
+      |> assign_new(:filters_label, fn -> "🔍 Filters" end)
       |> assign_new(:empty_message, fn -> "No results found" end)
       |> assign_new(:class, fn -> "" end)
       |> assign_new(:tenant, fn -> nil end)
@@ -372,6 +379,7 @@ defmodule Cinder.Table do
         show_filters={@show_filters}
         show_pagination={@show_pagination}
         loading_message={@loading_message}
+        filters_label={@filters_label}
         empty_message={@empty_message}
         col={@processed_columns}
         row_click={@row_click}

--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -53,6 +53,9 @@ defmodule Cinder.Table.LiveComponent do
           filters={@filters}
           theme={@theme}
           target={@myself}
+          filters_label={@filters_label}
+          active_label={@active_label}
+          clear_all_label={@clear_all_label}
         />
       </div>
 
@@ -103,7 +106,7 @@ defmodule Cinder.Table.LiveComponent do
             <circle class={@theme.loading_spinner_circle_class} {@theme.loading_spinner_circle_data} cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class={@theme.loading_spinner_path_class} {@theme.loading_spinner_path_data} fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
-          Loading...
+          {@loading_message}
         </div>
       </div>
 
@@ -113,6 +116,9 @@ defmodule Cinder.Table.LiveComponent do
           page_info={@page_info}
           theme={@theme}
           myself={@myself}
+          page_label={@page_label}
+          showing_label={@showing_label}
+          of_label={@of_label}
         />
       </div>
     </div>
@@ -374,9 +380,9 @@ defmodule Cinder.Table.LiveComponent do
     <div class={@theme.pagination_container_class} {@theme.pagination_container_data}>
       <!-- Left side: Page info -->
       <div class={@theme.pagination_info_class} {@theme.pagination_info_data}>
-        Page {@page_info.current_page} of {@page_info.total_pages}
+        {@page_label} {@page_info.current_page} {@of_label} {@page_info.total_pages}
         <span class={@theme.pagination_count_class} {@theme.pagination_count_data}>
-          (showing {@page_info.start_index}-{@page_info.end_index} of {@page_info.total_count})
+          ({@showing_label} {@page_info.start_index}-{@page_info.end_index} {@of_label} {@page_info.total_count})
         </span>
       </div>
 

--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -53,9 +53,6 @@ defmodule Cinder.Table.LiveComponent do
           filters={@filters}
           theme={@theme}
           target={@myself}
-          filters_label={@filters_label}
-          active_label={@active_label}
-          clear_all_label={@clear_all_label}
         />
       </div>
 
@@ -106,7 +103,7 @@ defmodule Cinder.Table.LiveComponent do
             <circle class={@theme.loading_spinner_circle_class} {@theme.loading_spinner_circle_data} cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class={@theme.loading_spinner_path_class} {@theme.loading_spinner_path_data} fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
-          {@loading_message}
+          Loading...
         </div>
       </div>
 
@@ -116,9 +113,6 @@ defmodule Cinder.Table.LiveComponent do
           page_info={@page_info}
           theme={@theme}
           myself={@myself}
-          page_label={@page_label}
-          showing_label={@showing_label}
-          of_label={@of_label}
         />
       </div>
     </div>
@@ -380,9 +374,9 @@ defmodule Cinder.Table.LiveComponent do
     <div class={@theme.pagination_container_class} {@theme.pagination_container_data}>
       <!-- Left side: Page info -->
       <div class={@theme.pagination_info_class} {@theme.pagination_info_data}>
-        {@page_label} {@page_info.current_page} {@of_label} {@page_info.total_pages}
+        Page {@page_info.current_page} of {@page_info.total_pages}
         <span class={@theme.pagination_count_class} {@theme.pagination_count_data}>
-          ({@showing_label} {@page_info.start_index}-{@page_info.end_index} {@of_label} {@page_info.total_count})
+          (showing {@page_info.start_index}-{@page_info.end_index} of {@page_info.total_count})
         </span>
       </div>
 

--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -53,6 +53,7 @@ defmodule Cinder.Table.LiveComponent do
           filters={@filters}
           theme={@theme}
           target={@myself}
+          filters_label={@filters_label}
         />
       </div>
 


### PR DESCRIPTION
Adds the ability to customise:

- The label for the clear all button (default: "Clear all")
- The label for filtering (default: "🔍 Filters")
- The label for active filters indicator (default: "active")
- The label for the pagination controls (default: "Page")
- The label for the pagination controls (default: "of")
- The label for the pagination controls (default: "of")

Now, I'm not entirely sure that this is the way you want to go with it but in the case it is usable at all, here it is 🙂

Regarding testing, I wasn't immediately clear on how you would like to have this tested. I'd be happy to provide tests given your direction.

I'd like to thing that this resolves #23.

Sidenote:
> So, for localising a lot of tables one will have to provide those tables quite a few times but I guess that's just the way things work? I assume that one cannot putt calls to `Gettext` in config.