### PR TITLE
Fix page_size when refreshing tables

### DIFF
--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -393,7 +393,7 @@ defmodule Cinder.Table do
         query={@normalized_query}
         actor={@resolved_options.actor}
         tenant={@resolved_options.tenant}
-        page_size={@parsed_page_size}
+        page_size_config={@parsed_page_size}
         theme={resolve_theme(@theme)}
         url_filters={get_url_filters(@url_state)}
         url_page={get_url_page(@url_state)}

--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -375,14 +375,14 @@ defmodule Cinder.Table do
     show_filters = determine_show_filters(assigns, processed_columns)
 
     # Parse page_size configuration
-    parsed_page_size = parse_page_size_config(assigns.page_size)
+    page_size_config = parse_page_size_config(assigns.page_size)
 
     assigns =
       assigns
       |> assign(:normalized_query, normalized_query)
       |> assign(:processed_columns, processed_columns)
       |> assign(:resolved_options, resolved_options)
-      |> assign(:parsed_page_size, parsed_page_size)
+      |> assign(:page_size_config, page_size_config)
       |> assign_new(:show_filters, fn -> show_filters end)
 
     ~H"""
@@ -393,7 +393,7 @@ defmodule Cinder.Table do
         query={@normalized_query}
         actor={@resolved_options.actor}
         tenant={@resolved_options.tenant}
-        page_size_config={@parsed_page_size}
+        page_size_config={@page_size_config}
         theme={resolve_theme(@theme)}
         url_filters={get_url_filters(@url_state)}
         url_page={get_url_page(@url_state)}

--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -607,8 +607,7 @@ defmodule Cinder.Table.LiveComponent do
   defp assign_defaults(socket) do
     assigns = socket.assigns
 
-    # The page_size comes from the table component already parsed as a config struct
-    page_size_config = assigns[:page_size] || %{selected_page_size: 25, page_size_options: [], default_page_size: 25, configurable: false}
+    page_size_config = assigns[:page_size_config] || %{selected_page_size: 25, page_size_options: [], default_page_size: 25, configurable: false}
     selected_page_size = page_size_config.selected_page_size
 
     socket


### PR DESCRIPTION
`page_size` is expected to be a map, but is an integer after the first update, which leads to this error when refreshing the table:

```
14:46:25.033 pid=<0.33951.0> [error] GenServer #PID<0.33951.0> terminating
** (KeyError) key :selected_page_size not found in: 25

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
    (cinder 0.5.5) lib/cinder/table/live_component.ex:612: Cinder.Table.LiveComponent.assign_defaults/1
    (cinder 0.5.5) lib/cinder/table/live_component.ex:29: Cinder.Table.LiveComponent.update/2
    (phoenix_live_view 1.1.4) lib/phoenix_live_view/utils.ex:492: Phoenix.LiveView.Utils.maybe_call_update!/3
    (phoenix_live_view 1.1.4) lib/phoenix_live_view/diff.ex:289: anonymous fn/4 in Phoenix.LiveView.Diff.update_component/3
    (telemetry 1.3.0) deps/telemetry/src/telemetry.erl:324: :telemetry.span/3
    (phoenix_live_view 1.1.4) lib/phoenix_live_view/diff.ex:288: anonymous fn/4 in Phoenix.LiveView.Diff.update_component/3
    (phoenix_live_view 1.1.4) lib/phoenix_live_view/diff.ex:222: Phoenix.LiveView.Diff.write_component/4
    (phoenix_live_view 1.1.4) lib/phoenix_live_view/diff.ex:280: Phoenix.LiveView.Diff.update_component/3
    (phoenix_live_view 1.1.4) lib/phoenix_live_view/channel.ex:321: Phoenix.LiveView.Channel.handle_info/2
    (stdlib 7.0.2) gen_server.erl:2434: :gen_server.try_handle_info/3
    (stdlib 7.0.2) gen_server.erl:2420: :gen_server.handle_msg/3
    (stdlib 7.0.2) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
```

Sorry for not adding any tests, but I could not see an easy way to test this (without actually rendering the component).