### PR TITLE
Don't empty data on refresh.

### DIFF
--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -680,7 +680,7 @@ defmodule Cinder.Table.LiveComponent do
     |> assign(:page_size_config, page_size_config)
     |> assign(:current_page, assigns[:current_page] || 1)
     |> assign(:loading, false)
-    |> assign(:data, [])
+    |> assign(:data, assigns[:data] || [])
     |> assign(:sort_by, assigns[:sort_by] || extract_initial_sorts(assigns))
     |> assign(:filters, assigns[:filters] || %{})
     |> assign(:search_term, assigns[:search_term] || "")


### PR DESCRIPTION
This caused the table to "flash"/"flicker" because the table is quickly re-rendered with no data (i.e. no rows), then rendered with the new data (typically very soon thereafter).

This also prevented morphdom from working correctly, as the previous DOM was destroyed by the empty render.

Before:

https://github.com/user-attachments/assets/9a635015-0baa-4c87-8679-3ee55f62f003

After:

https://github.com/user-attachments/assets/bdf64b67-3eba-4ca5-b9b5-47b7d768bad7

At first I thought this was an issue with my setup, but you can clearly see this problem happening in the official demo video.

It may be a good idea to allow the user to configure this behavior as an option, but in my opinion this new behavior should be on by default.

