### PR TITLE
Add aria-label to boolean input

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,6 +5,7 @@ locals_without_parens = [
 
 # Used by "mix format"
 [
+  import_deps: [:phoenix],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   locals_without_parens: locals_without_parens,
   export: [

--- a/lib/cinder/filters/boolean.ex
+++ b/lib/cinder/filters/boolean.ex
@@ -32,40 +32,33 @@ defmodule Cinder.Filters.Boolean do
 
     ~H"""
     <div class={@theme.filter_boolean_container_class} {@theme.filter_boolean_container_data}>
-      <label class={@theme.filter_boolean_option_class} {@theme.filter_boolean_option_data}>
-        <input
-          type="radio"
-          name={field_name(@column.field)}
-          value=""
-          checked={@current_boolean_value == "" || @current_boolean_value == "all"}
-          class={@theme.filter_boolean_radio_class}
-          {@theme.filter_boolean_radio_data}
-        />
-        <span class={@theme.filter_boolean_label_class} {@theme.filter_boolean_label_data}>{@all_label}</span>
-      </label>
-      <label class={@theme.filter_boolean_option_class} {@theme.filter_boolean_option_data}>
-        <input
-          type="radio"
-          name={field_name(@column.field)}
-          value="true"
-          checked={@current_boolean_value == "true"}
-          class={@theme.filter_boolean_radio_class}
-          {@theme.filter_boolean_radio_data}
-        />
-        <span class={@theme.filter_boolean_label_class} {@theme.filter_boolean_label_data}>{@true_label}</span>
-      </label>
-      <label class={@theme.filter_boolean_option_class} {@theme.filter_boolean_option_data}>
-        <input
-          type="radio"
-          name={field_name(@column.field)}
-          value="false"
-          checked={@current_boolean_value == "false"}
-          class={@theme.filter_boolean_radio_class}
-          {@theme.filter_boolean_radio_data}
-        />
-        <span class={@theme.filter_boolean_label_class} {@theme.filter_boolean_label_data}>{@false_label}</span>
-      </label>
+      <.option name={field_name(@column.field)} label={@all_label} value="" checked={@current_boolean_value in ["", "all"]} theme={@theme} />
+      <.option name={field_name(@column.field)} label={@true_label} value="true" checked={@current_boolean_value == "true"} theme={@theme} />
+      <.option name={field_name(@column.field)} label={@false_label} value="false" checked={@current_boolean_value == "false"} theme={@theme} />
     </div>
+    """
+  end
+
+  attr :name, :string, required: true
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+  attr :checked, :boolean, required: true
+  attr :theme, :map, required: true
+
+  defp option(assigns) do
+    ~H"""
+    <label class={@theme.filter_boolean_option_class} {@theme.filter_boolean_option_data}>
+      <input
+        type="radio"
+        name={@name}
+        value={@value}
+        checked={@checked}
+        class={@theme.filter_boolean_radio_class}
+        aria-label={@label}
+        {@theme.filter_boolean_radio_data}
+      />
+      <span class={@theme.filter_boolean_label_class} {@theme.filter_boolean_label_data}>{@label}</span>
+    </label>
     """
   end
 


### PR DESCRIPTION
This allows styling them as button join group when using DaisyUI: https://daisyui.com/components/join/

Theme:

```elixir
set :filter_boolean_container_class, "flex h-[36px] items-center join"
set :filter_boolean_option_class, nil
set :filter_boolean_radio_class, "btn join-item"
set :filter_boolean_label_class, "hidden"
```

Preview:

<img width="486" height="94" alt="Screenshot 2025-09-01 at 12 41 48" src="https://github.com/user-attachments/assets/09dae473-e802-46e7-aead-1ce7a4d5e277" />

As a sidenote, the "All" and clear buttons have the same effect. Maybe one of them could be removed? I tried hiding the clear button for the boolean inputs with something like this but it did not work:

```elixir
set :filter_input_wrapper_class, "form-control float-left mr-4 mb-4 group"
set :filter_clear_button_class, ~S(btn btn-ghost btn-xs ml-2 group-has-[[data-key=filter\_boolean\_container\_class]]:hidden)
```