### PR TITLE
Add passthrough of non-special-handled attributes for columns

### DIFF
--- a/lib/cinder/table/live_component.ex
+++ b/lib/cinder/table/live_component.ex
@@ -92,7 +92,7 @@ defmodule Cinder.Table.LiveComponent do
                 class={get_row_classes(@theme.row_class, @row_click)}
                 {@theme.row_data}
                 phx-click={@row_click && @row_click.(item)}>
-              <td :for={column <- @columns} class={[@theme.td_class, column.class]} {@theme.td_data}>
+              <td :for={column <- @columns} class={[@theme.td_class, column.class]} {@theme.td_data} {column.global_attrs}>
                 {render_slot(column.slot, item)}
               </td>
             </tr>


### PR DESCRIPTION
This is required to do things like css-rewriting the table to stacked cards etc (so you can pass through data-label="column name here" and similar).

It also enables a11y features like setting aria-label.