### PR TITLE
feature: emit the IDs currently viewed by user

### DIFF
--- a/lib/cinder/collection.ex
+++ b/lib/cinder/collection.ex
@@ -182,6 +182,17 @@ defmodule Cinder.Collection do
     doc: "Function to call when a row/item is clicked. Receives the item as argument."
   )
 
+  attr(:id_field, :atom,
+    default: :id,
+    doc: "Field to use as ID for visible ID tracking (defaults to :id)"
+  )
+
+  attr(:emit_visible_ids, :boolean,
+    default: false,
+    doc:
+      "When true, emits {:cinder_visible_ids, collection_id, [id]} to parent after each data load"
+  )
+
   slot :col do
     attr(:field, :string,
       required: false,
@@ -361,6 +372,8 @@ defmodule Cinder.Collection do
         search_placeholder={@search_placeholder}
         search_fn={@search_fn}
         pagination_mode={@pagination_mode}
+        id_field={@id_field}
+        emit_visible_ids={@emit_visible_ids}
       />
     </div>
     """

--- a/lib/cinder/live_component.ex
+++ b/lib/cinder/live_component.ex
@@ -288,6 +288,7 @@ defmodule Cinder.LiveComponent do
       |> assign(:page, page)
       # Update keyset cursors for navigation (only relevant in keyset mode)
       |> maybe_update_keyset_cursors(page)
+      |> maybe_emit_visible_ids(page.results)
 
     {:noreply, socket}
   end
@@ -348,6 +349,18 @@ defmodule Cinder.LiveComponent do
   end
 
   defp maybe_update_keyset_cursors(socket, _page), do: socket
+
+  # Emit visible IDs to parent LiveView for selective refresh optimization
+  defp maybe_emit_visible_ids(socket, results) do
+    if socket.assigns[:emit_visible_ids] do
+      id_field = socket.assigns[:id_field] || :id
+      collection_id = socket.assigns[:id]
+      visible_ids = Enum.map(results, &Map.get(&1, id_field))
+      send(self(), {:cinder_visible_ids, collection_id, visible_ids})
+    end
+
+    socket
+  end
 
   defp get_keyset_from_result(nil), do: nil
 

--- a/lib/cinder/refresh.ex
+++ b/lib/cinder/refresh.ex
@@ -26,6 +26,27 @@ defmodule Cinder.Refresh do
         {:noreply, refresh_tables(socket, ["users-table", "orders-table"])}
       end
 
+  ## Tracking Visible Records
+
+  Collections can emit the IDs of currently visible records to the parent LiveView.
+  Enable this with `emit_visible_ids={true}`:
+
+      <Cinder.collection emit_visible_ids={true} ...>
+
+  Then handle the message in your LiveView:
+
+      def handle_info({:cinder_visible_ids, collection_id, ids}, socket) do
+        visible_ids = socket.assigns[:cinder_visible_ids] || %{}
+        {:noreply, assign(socket, :cinder_visible_ids, Map.put(visible_ids, collection_id, MapSet.new(ids)))}
+      end
+
+  This is useful when you need to know which records the user is looking at,
+  for example to conditionally refresh on external events:
+
+      def handle_info({:record_changed, id}, socket) do
+        {:noreply, refresh_if_visible(socket, "my-collection", id)}
+      end
+
   ## Refresh Behavior
 
   When a collection is refreshed:
@@ -98,5 +119,57 @@ defmodule Cinder.Refresh do
     end)
 
     socket
+  end
+
+  @doc """
+  Refreshes a collection only if any of the given IDs are currently visible.
+
+  Checks if the provided ID(s) are in the set of visible records for the collection.
+  If any match, the collection is refreshed; otherwise, the socket is returned unchanged.
+
+  Requires the collection to have `emit_visible_ids={true}` and the parent LiveView
+  to store visible IDs via handling `{:cinder_visible_ids, collection_id, ids}`.
+
+  ## Parameters
+
+  - `socket` - The LiveView socket (must have `:cinder_visible_ids` in assigns)
+  - `collection_id` - The ID of the collection to conditionally refresh
+  - `ids` - A single ID or list of IDs to check against visible set
+
+  ## Returns
+
+  The socket (unchanged, but refresh message sent if any ID is visible).
+
+  ## Examples
+
+      # In parent LiveView, store visible IDs
+      def handle_info({:cinder_visible_ids, collection_id, ids}, socket) do
+        visible_ids = socket.assigns[:cinder_visible_ids] || %{}
+        {:noreply, assign(socket, :cinder_visible_ids, Map.put(visible_ids, collection_id, MapSet.new(ids)))}
+      end
+
+      # Refresh only if the changed record is visible
+      def handle_info({:record_updated, record}, socket) do
+        {:noreply, refresh_if_visible(socket, "my-collection", record.id)}
+      end
+
+      # With multiple IDs
+      def handle_info({:records_updated, records}, socket) do
+        {:noreply, refresh_if_visible(socket, "my-collection", Enum.map(records, & &1.id))}
+      end
+  """
+  def refresh_if_visible(socket, collection_id, ids)
+      when is_binary(collection_id) and is_list(ids) do
+    visible_ids = get_in(socket.assigns, [:cinder_visible_ids, collection_id])
+
+    if visible_ids && Enum.any?(ids, &(&1 in visible_ids)) do
+      refresh_table(socket, collection_id)
+    else
+      socket
+    end
+  end
+
+  def refresh_if_visible(socket, collection_id, id) when is_binary(collection_id) do
+    refresh_if_visible(socket, collection_id, [id])
   end
 end

--- a/lib/cinder/table/refresh.ex
+++ b/lib/cinder/table/refresh.ex
@@ -26,4 +26,7 @@ defmodule Cinder.Table.Refresh do
 
   @deprecated "Use Cinder.Refresh.refresh_tables/2 instead"
   defdelegate refresh_tables(socket, table_ids), to: Cinder.Refresh
+
+  @deprecated "Use Cinder.Refresh.refresh_if_visible/3 instead"
+  defdelegate refresh_if_visible(socket, table_id, ids), to: Cinder.Refresh
 end


### PR DESCRIPTION
we had this issue where we wanted refresh on pubsub, but very busy tables basically never stopped blinking and became entirely unusable. 

This solves that by emitting the currently visible resource ids, so you can (decide to) reload only if something that the user is actively looking at has changed.