### PR TITLE
fix: remove duplicate filter_options concatenation in process_filter_slots

### DIFF
--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -727,7 +727,8 @@ defmodule Cinder.Table do
 
       # Build filter configuration in unified format for determine_filter_type
       base_options = if filter_value, do: [value: filter_value], else: []
-      all_options = base_options ++ extra_options ++ (filter_options || [])
+      # Note: filter_options is already included in extra_options as `options: filter_options`
+      all_options = base_options ++ extra_options
 
       filter_config =
         if filter_type do


### PR DESCRIPTION
## Summary

Fixes a bug where `filter_options` were being added twice to `all_options` in `process_filter_slots/2`, causing `Keyword.merge/2` to fail with an `ArgumentError`.

## Problem

The `filter_options` extracted at line 700 were being added twice:
1. As `options: filter_options` in `extra_options` (line 718)
2. As raw tuples via `++ (filter_options || [])` (line 730)

When `filter_options` contains tuples like `[{"Label", "value"}]` (standard select options format), the resulting `all_options` becomes:
```elixir
[{:options, [{"Label", "value"}]}, {"Label", "value"}]
```

This is not a valid keyword list because `{"Label", "value"}` is not a `{atom, value}` tuple, causing `Keyword.merge/2` to fail downstream.

## Solution

Remove the duplicate concatenation at line 730 since `filter_options` is already included via the `:options` key in `extra_options`.

## Error

```
ArgumentError at GET /admin/locations
expected a keyword list as the second argument, got: 
[{:options, [{"Org A", "uuid-a"}, {"Org B", "uuid-b"}]}, {"Org A", "uuid-a"}, {"Org B", "uuid-b"}]
```

## Affected

- Any filter using the `options` attribute
- Particularly affects custom filter types like `bulk_multi_select`

🤖 Generated with [Claude Code](https://claude.com/claude-code)