### PR TITLE
fix: remove duplicate filter_options concatenation in process_filter_slots (main branch)

### DIFF
--- a/lib/cinder/collection.ex
+++ b/lib/cinder/collection.ex
@@ -576,7 +576,8 @@ defmodule Cinder.Collection do
 
       # Build filter configuration in unified format for determine_filter_type
       base_options = if filter_value, do: [value: filter_value], else: []
-      all_options = base_options ++ extra_options ++ (filter_options || [])
+      # Note: filter_options is already included in extra_options as `options: filter_options`
+      all_options = base_options ++ extra_options
 
       filter_config =
         if filter_type do


### PR DESCRIPTION
## Summary

Same fix as #99 but for the main branch (0.9.x).

Fixes a bug where `filter_options` were being added twice to `all_options` in `process_filter_slots/2` in `Cinder.Collection`, causing `Keyword.merge/2` to fail with an `ArgumentError`.

## Problem

The `filter_options` extracted at line 547 were being added twice:
1. As `options: filter_options` in `extra_options` (line 567)
2. As raw tuples via `++ (filter_options || [])` (line 579)

When `filter_options` contains tuples like `[{"Label", "value"}]` (standard select options format), the resulting `all_options` becomes invalid, breaking `Keyword.merge/2`.

## Solution

Remove the duplicate concatenation at line 579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)