### PR TITLE
fix clicking on label in multicheckbox filter not selecting the checkbox

### DIFF
--- a/lib/cinder/filters/multi_checkboxes.ex
+++ b/lib/cinder/filters/multi_checkboxes.ex
@@ -59,15 +59,17 @@ defmodule Cinder.Filters.MultiCheckboxes do
     ~H"""
     <div class={@theme.filter_multicheckboxes_container_class} {@theme.filter_multicheckboxes_container_data}>
       <div :for={{label, value} <- @options} class={@theme.filter_multicheckboxes_option_class} {@theme.filter_multicheckboxes_option_data}>
-        <input
-          type="checkbox"
-          name={field_name(@column.field) <> "[]"}
-          value={to_string(value)}
-          checked={to_string(value) in Enum.map(@selected_values, &to_string/1)}
-          class={@theme.filter_multicheckboxes_checkbox_class}
-          {@theme.filter_multicheckboxes_checkbox_data}
-        />
-        <label class={@theme.filter_multicheckboxes_label_class} {@theme.filter_multicheckboxes_label_data}>{label}</label>
+        <label>
+          <input
+            type="checkbox"
+            name={field_name(@column.field) <> "[]"}
+            value={to_string(value)}
+            checked={to_string(value) in Enum.map(@selected_values, &to_string/1)}
+            class={@theme.filter_multicheckboxes_checkbox_class}
+            {@theme.filter_multicheckboxes_checkbox_data}
+          />
+          <span class={@theme.filter_multicheckboxes_label_class} {@theme.filter_multicheckboxes_label_data}>{label}</span>
+        </label>
       </div>
     </div>
     """


### PR DESCRIPTION
In a `multicheckbox` filter like these, I wasn't able to select the checkboxes by clicking on the labels next to it, this PR fixes that.

<img width="335" height="143" alt="image" src="https://github.com/user-attachments/assets/168d4a8e-4524-4197-a74a-25e30cf9d045" />
