### PR TITLE
fix show_filters toggle in list and grid

### DIFF
--- a/lib/cinder/renderers/grid.ex
+++ b/lib/cinder/renderers/grid.ex
@@ -41,7 +41,7 @@ defmodule Cinder.Renderers.Grid do
     ~H"""
     <div class={[@theme.container_class, "relative"]} data-key="container_class">
       <!-- Controls Area (filters + sort) -->
-      <div :if={@show_filters or (@show_sort && SortControls.has_sortable_columns?(@columns))} class={[@theme.controls_class, "!flex !flex-col"]} data-key="controls_class">
+      <div :if={@show_filters || (@show_sort && SortControls.has_sortable_columns?(@columns))} class={[@theme.controls_class, "!flex !flex-col"]} data-key="controls_class">
         <!-- Filter Controls (including search) -->
         <Cinder.FilterManager.render_filter_controls
           :if={@show_filters}

--- a/lib/cinder/renderers/list.ex
+++ b/lib/cinder/renderers/list.ex
@@ -39,7 +39,7 @@ defmodule Cinder.Renderers.List do
     ~H"""
     <div class={[@theme.container_class, "relative"]} data-key="container_class">
       <!-- Controls Area (filters + sort) -->
-      <div :if={@show_filters or (@show_sort && SortControls.has_sortable_columns?(@columns))} class={[@theme.controls_class, "!flex !flex-col"]} data-key="controls_class">
+      <div :if={@show_filters || (@show_sort && SortControls.has_sortable_columns?(@columns))} class={[@theme.controls_class, "!flex !flex-col"]} data-key="controls_class">
         <!-- Filter Controls (including search) -->
         <Cinder.FilterManager.render_filter_controls
           :if={@show_filters}

--- a/test/cinder/renderers/grid_renderer_test.exs
+++ b/test/cinder/renderers/grid_renderer_test.exs
@@ -61,6 +61,16 @@ defmodule Cinder.Renderers.GridTest do
   end
 
   describe "data-key attributes" do
+    test "supports toggle filter mode without raising" do
+      assigns =
+        base_assigns()
+        |> Map.put(:show_filters, :toggle)
+
+      html = render_component(&GridRenderer.render/1, assigns)
+
+      assert html =~ ~s(data-key="controls_class")
+    end
+
     test "includes data-key for grid container when using theme classes" do
       assigns = base_assigns()
 

--- a/test/cinder/renderers/list_renderer_test.exs
+++ b/test/cinder/renderers/list_renderer_test.exs
@@ -60,6 +60,16 @@ defmodule Cinder.Renderers.ListTest do
   end
 
   describe "data-key attributes" do
+    test "supports toggle filter mode without raising" do
+      assigns =
+        base_assigns()
+        |> Map.put(:show_filters, :toggle)
+
+      html = render_component(&ListRenderer.render/1, assigns)
+
+      assert html =~ ~s(data-key="controls_class")
+    end
+
     test "includes data-key for list container when using theme classes" do
       assigns = base_assigns()
 


### PR DESCRIPTION
Got a bad boolean error before this fix, since it was passed an atom, but expected a bool.