### PR TITLE
Respect Ash disable_async? for data loading

### DIFF
--- a/lib/cinder/live_component.ex
+++ b/lib/cinder/live_component.ex
@@ -580,13 +580,18 @@ defmodule Cinder.LiveComponent do
   # ============================================================================
 
   @impl true
-  def handle_async(:load_data, {:ok, result}, socket) do
-    {:noreply, handle_result(result, socket)}
+  def handle_async(:load_data, {:ok, {:ok, page}}, socket) do
+    {:noreply, handle_result({:ok, page}, socket)}
+  end
+
+  @impl true
+  def handle_async(:load_data, {:ok, {:error, error}}, socket) do
+    {:noreply, handle_result({:error, error}, socket)}
   end
 
   @impl true
   def handle_async(:load_data, {:exit, reason}, socket) do
-    {:noreply, handle_result({:error, reason}, socket)}
+    {:noreply, handle_result({:exit, reason}, socket)}
   end
 
   defp handle_result({:ok, page}, socket) do
@@ -608,6 +613,25 @@ defmodule Cinder.LiveComponent do
         sort_by: socket.assigns.sort_by,
         current_page: socket.assigns.current_page,
         error: inspect(error)
+      }
+    )
+
+    socket
+    |> assign(:loading, false)
+    |> assign(:error, true)
+    |> assign(:data, [])
+    |> assign(:page, nil)
+  end
+
+  defp handle_result({:exit, reason}, socket) do
+    Logger.error(
+      "Cinder query crashed for #{inspect(socket.assigns.query)}: #{inspect(reason)}",
+      %{
+        resource: socket.assigns.query,
+        filters: socket.assigns.filters,
+        sort_by: socket.assigns.sort_by,
+        current_page: socket.assigns.current_page,
+        reason: inspect(reason)
       }
     )
 

--- a/lib/cinder/live_component.ex
+++ b/lib/cinder/live_component.ex
@@ -1025,9 +1025,13 @@ defmodule Cinder.LiveComponent do
     |> assign(:error, false)
     |> then(fn socket ->
       if Application.get_env(:ash, :disable_async?) do
-        resource_var
-        |> Cinder.QueryBuilder.build_and_execute(options)
-        |> handle_result(socket)
+        try do
+          resource_var
+          |> Cinder.QueryBuilder.build_and_execute(options)
+          |> handle_result(socket)
+        rescue
+          e -> handle_result({:exit, e}, socket)
+        end
       else
         start_async(socket, :load_data, fn ->
           Cinder.QueryBuilder.build_and_execute(resource_var, options)

--- a/lib/cinder/live_component.ex
+++ b/lib/cinder/live_component.ex
@@ -580,21 +580,26 @@ defmodule Cinder.LiveComponent do
   # ============================================================================
 
   @impl true
-  def handle_async(:load_data, {:ok, {:ok, page}}, socket) do
-    socket =
-      socket
-      |> assign(:loading, false)
-      |> assign(:error, false)
-      |> assign(:data, page.results)
-      |> assign(:page, page)
-      # Update keyset cursors for navigation (only relevant in keyset mode)
-      |> maybe_update_keyset_cursors(page)
-
-    {:noreply, socket}
+  def handle_async(:load_data, {:ok, result}, socket) do
+    {:noreply, handle_result(result, socket)}
   end
 
   @impl true
-  def handle_async(:load_data, {:ok, {:error, error}}, socket) do
+  def handle_async(:load_data, {:exit, reason}, socket) do
+    {:noreply, handle_result({:error, reason}, socket)}
+  end
+
+  defp handle_result({:ok, page}, socket) do
+    socket
+    |> assign(:loading, false)
+    |> assign(:error, false)
+    |> assign(:data, page.results)
+    |> assign(:page, page)
+    # Update keyset cursors for navigation (only relevant in keyset mode)
+    |> maybe_update_keyset_cursors(page)
+  end
+
+  defp handle_result({:error, error}, socket) do
     Logger.error(
       "Cinder query failed for #{inspect(socket.assigns.query)}: #{inspect(error)}",
       %{
@@ -606,37 +611,11 @@ defmodule Cinder.LiveComponent do
       }
     )
 
-    socket =
-      socket
-      |> assign(:loading, false)
-      |> assign(:error, true)
-      |> assign(:data, [])
-      |> assign(:page, nil)
-
-    {:noreply, socket}
-  end
-
-  @impl true
-  def handle_async(:load_data, {:exit, reason}, socket) do
-    Logger.error(
-      "Cinder query crashed for #{inspect(socket.assigns.query)}: #{inspect(reason)}",
-      %{
-        resource: socket.assigns.query,
-        filters: socket.assigns.filters,
-        sort_by: socket.assigns.sort_by,
-        current_page: socket.assigns.current_page,
-        reason: inspect(reason)
-      }
-    )
-
-    socket =
-      socket
-      |> assign(:loading, false)
-      |> assign(:error, true)
-      |> assign(:data, [])
-      |> assign(:page, nil)
-
-    {:noreply, socket}
+    socket
+    |> assign(:loading, false)
+    |> assign(:error, true)
+    |> assign(:data, [])
+    |> assign(:page, nil)
   end
 
   defp maybe_update_keyset_cursors(socket, %Ash.Page.Keyset{} = page) do
@@ -1020,8 +999,16 @@ defmodule Cinder.LiveComponent do
     socket
     |> assign(:loading, true)
     |> assign(:error, false)
-    |> start_async(:load_data, fn ->
-      Cinder.QueryBuilder.build_and_execute(resource_var, options)
+    |> then(fn socket ->
+      if Application.get_env(:ash, :disable_async?) do
+        resource_var
+        |> Cinder.QueryBuilder.build_and_execute(options)
+        |> handle_result(socket)
+      else
+        start_async(socket, :load_data, fn ->
+          Cinder.QueryBuilder.build_and_execute(resource_var, options)
+        end)
+      end
     end)
   end
 end


### PR DESCRIPTION
I'm using Cinder with [`Ecto.Adapters.SQL.Sandbox`](https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.Sandbox.html) in LiveView tests, and have been seeing a lot of DB connection contention (`DBConnection.ConnectionError`, "An error occurred while loading data", etc).

This is because Cinder uses `start_async` to load table data, which spawns a Task process that competes for the test's single sandboxed DB connection. It's especially pronounced on pages with multiple Cinder tables—each table spawns its own Task on mount, which get dropped under load and result in flaky test failures.

Ash has the same problem (e.g. when parallelizing queries), but provides a [`disable_async?`](https://hexdocs.pm/ash/testing.html#async-tests) flag. Since Cinder depends on Ash, this PR adds a check for the same flag to run data loading without `start_async`. Also some slight refactoring so the logic can be shared by sync & async code paths.

Note: I looked at the testing setup but seems like they all run against ETS, so no tests along with this PR. It would require setting up `ecto_sql` with an actual DB as a testing dependency.