### PR TITLE
feat: added user-editable column preferences support

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,0 +1,102 @@
+/**
+ * Cinder LiveView hooks.
+ *
+ *   import { createCinderHooks } from "cinder"
+ *   import Sortable from "sortablejs" // optional — needed for column drag-to-reorder
+ *
+ *   const liveSocket = new LiveSocket("/live", Socket, {
+ *     hooks: { ...createCinderHooks({ Sortable }) }
+ *   })
+ *
+ * Without `sortablejs`, column visibility and persistence still work; only
+ * drag-to-reorder is disabled.
+ */
+
+const STORAGE_PREFIX = "cinder:column_prefs:";
+
+/** Per-table localStorage I/O for column visibility and order. */
+function createColumnPrefsHook() {
+  return {
+    mounted() {
+      this.tableId = this.el.dataset.cinderTableId;
+      this.storageKey = STORAGE_PREFIX + this.tableId;
+
+      this.handleEvent("cinder:column_prefs_changed", (payload) => {
+        if (!payload || payload.id !== this.tableId) return;
+        this.writePrefs({ order: payload.order, hidden: payload.hidden });
+      });
+
+      const stored = this.readPrefs() || {};
+      this.pushEventTo(this.el, "apply_column_preferences", stored);
+    },
+
+    readPrefs() {
+      try {
+        const raw = window.localStorage.getItem(this.storageKey);
+        return raw ? JSON.parse(raw) : null;
+      } catch (e) {
+        console.warn("[cinder] failed to read column prefs", e);
+        return null;
+      }
+    },
+
+    writePrefs(prefs) {
+      try {
+        window.localStorage.setItem(this.storageKey, JSON.stringify(prefs));
+      } catch (e) {
+        console.warn("[cinder] failed to persist column prefs", e);
+      }
+    },
+  };
+}
+
+/** SortableJS binding on the prefs drawer's column list. No-op without Sortable. */
+function createColumnSortableHook(Sortable) {
+  return {
+    mounted() {
+      if (!Sortable) return;
+      this.sortable = Sortable.create(this.el, this.sortableOptions());
+    },
+
+    updated() {
+      if (Sortable && !this.sortable) {
+        this.sortable = Sortable.create(this.el, this.sortableOptions());
+      }
+    },
+
+    sortableOptions() {
+      return {
+        animation: 150,
+        filter: '[data-reorderable="false"], input',
+        preventOnFilter: false,
+        onEnd: () => this.pushOrder(),
+      };
+    },
+
+    destroyed() {
+      if (this.sortable) {
+        this.sortable.destroy();
+        this.sortable = null;
+      }
+    },
+
+    pushOrder() {
+      const order = Array.from(this.el.children)
+        .filter((el) => el.dataset.reorderable !== "false")
+        .map((el) => el.dataset.field)
+        .filter(Boolean);
+
+      this.pushEventTo(this.el, "reorder_columns", { order });
+    },
+  };
+}
+
+/** Pass `{ Sortable }` to enable drag-to-reorder. */
+export function createCinderHooks({ Sortable } = {}) {
+  return {
+    CinderColumnPrefs: createColumnPrefsHook(),
+    CinderColumnSortable: createColumnSortableHook(Sortable),
+  };
+}
+
+export default createCinderHooks;

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cinder",
+  "version": "0.1.0",
+  "description": "JS hooks for the Cinder Phoenix LiveView table library",
+  "license": "MIT",
+  "main": "js/index.js",
+  "module": "js/index.js",
+  "type": "module",
+  "files": ["js/"],
+  "peerDependencies": {
+    "sortablejs": ">=1.15.0"
+  },
+  "peerDependenciesMeta": {
+    "sortablejs": {
+      "optional": true
+    }
+  }
+}

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -10,6 +10,7 @@ This guide covers URL state management, relationships, embedded resources, refre
 - [Collection Refresh](#collection-refresh)
 - [Loading, Empty & Error States](#loading-empty-error-states)
 - [Performance Optimization](#performance-optimization)
+- [Column Preferences](#column-preferences)
 - [Selection & Bulk Actions](#selection--bulk-actions)
 
 **See also:** [Filters](filters.md) | [Sorting](sorting.md)
@@ -438,6 +439,97 @@ For slow queries, configure a timeout:
   ...
 </Cinder.collection>
 ```
+
+## Column Preferences
+
+Let end users customise which columns are visible and what order they appear in. Preferences persist to `localStorage` keyed by the table's `id`, so each user's choices survive across reloads.
+
+### Setup
+
+```heex
+<Cinder.collection
+  resource={MyApp.User}
+  actor={@current_user}
+  id="users-table"
+  column_preferences?
+>
+  <:col :let={user} field="id" hideable={false}>{user.id}</:col>
+  <:col :let={user} field="name" filter sort>{user.name}</:col>
+  <:col :let={user} field="email" filter>{user.email}</:col>
+  <:col :let={user} field="last_login_at" default_visible={false}>{user.last_login_at}</:col>
+  <:col reorderable={false}>
+    <.link navigate={~p"/users/#{user}"}>Edit</.link>
+  </:col>
+</Cinder.collection>
+```
+
+This adds an "Edit columns" button. Clicking it opens a side drawer with checkboxes and drag handles.
+
+### Per-column attributes
+
+| Attribute         | Default | Effect                                                      |
+| ----------------- | ------- | ----------------------------------------------------------- |
+| `hideable`        | `true`  | When `false`, the column can never be hidden by the user.   |
+| `reorderable`     | `true`  | When `false`, the column is pinned at its declared position. |
+| `default_visible` | `true`  | When `false`, the column ships hidden until the user opts in. |
+
+Action columns (no `field`) are automatically pinned and always visible.
+
+### JavaScript hook setup
+
+`mix cinder.install` does most of the wiring automatically:
+
+- adds `"cinder": "file:../deps/cinder/assets"` and `"sortablejs"` to your `assets/package.json`
+- prints the exact two-line addition you need to make in `assets/js/app.js`
+
+After running it:
+
+```sh
+mix cinder.install        # one-time, also configures Tailwind
+cd assets && npm install  # or pnpm / yarn
+```
+
+Then add the import + hook spread to `assets/js/app.js`:
+
+```js
+import { createCinderHooks } from "cinder"
+import Sortable from "sortablejs" // optional — only needed for drag-to-reorder
+
+let liveSocket = new LiveSocket("/live", Socket, {
+  // ...
+  hooks: {
+    ...createCinderHooks({ Sortable }),
+    // ...your existing hooks
+  }
+})
+```
+
+Without `sortablejs`, column visibility (checkboxes) still works — only drag-to-reorder is disabled. Without the hook entirely, prefs reset on every reload but the UI still functions during a session.
+
+### Server-side persistence (optional)
+
+To persist preferences on the server (per-user database row, ETS, etc.) instead of `localStorage`, listen to `on_columns_change`:
+
+```heex
+<Cinder.collection
+  resource={MyApp.User}
+  actor={@current_user}
+  id="users-table"
+  column_preferences?
+  on_columns_change={:columns_changed}
+>
+  ...
+</Cinder.collection>
+```
+
+```elixir
+def handle_info({:columns_changed, %{prefs: prefs, id: "users-table"}}, socket) do
+  MyApp.UserPrefs.save_table_layout(socket.assigns.current_user, "users-table", prefs)
+  {:noreply, socket}
+end
+```
+
+`prefs` has the shape `%{order: [field] | nil, hidden: [field]}`. To hydrate from server-side storage on mount, send the `apply_column_preferences` event to the LiveComponent with that same shape.
 
 ## Selection & Bulk Actions
 

--- a/i18n/gettext/cinder.pot
+++ b/i18n/gettext/cinder.pot
@@ -198,3 +198,28 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr ""

--- a/i18n/gettext/da/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/da/LC_MESSAGES/cinder.po
@@ -198,3 +198,28 @@ msgstr "Skriv for at søge flere muligheder..."
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr "Der opstod en fejl under indlæsning af data"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Luk"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Færdig"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr "Træk for at omarrangere"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr "Rediger kolonner"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr "Nulstil til standard"

--- a/i18n/gettext/de/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/de/LC_MESSAGES/cinder.po
@@ -195,3 +195,28 @@ msgstr "Tippen, um weitere Optionen zu suchen..."
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr "Beim Laden der Daten ist ein Fehler aufgetreten"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Schließen"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Fertig"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr "Zum Umsortieren ziehen"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr "Spalten bearbeiten"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr "Auf Standard zurücksetzen"

--- a/i18n/gettext/en/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/en/LC_MESSAGES/cinder.po
@@ -198,3 +198,28 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr ""
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr ""

--- a/i18n/gettext/es/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/es/LC_MESSAGES/cinder.po
@@ -198,3 +198,28 @@ msgstr "Escriba para buscar más opciones"
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr "Ocurrió un error al cargar los datos"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Cerrar"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Hecho"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr "Arrastrar para reordenar"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr "Editar columnas"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr "Restablecer valores predeterminados"

--- a/i18n/gettext/nl/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/nl/LC_MESSAGES/cinder.po
@@ -198,3 +198,28 @@ msgstr "Typ om meer opties te zoeken..."
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr "Er is een fout opgetreden bij het laden van gegevens"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Sluiten"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Klaar"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr "Versleep om te herordenen"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr "Kolommen bewerken"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr "Standaardinstellingen herstellen"

--- a/i18n/gettext/no/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/no/LC_MESSAGES/cinder.po
@@ -198,3 +198,28 @@ msgstr "Skriv for å søke flere alternativer..."
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr "Det oppstod en feil under lasting av data"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Lukk"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Ferdig"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr "Dra for å omorganisere"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr "Rediger kolonner"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr "Tilbakestill til standard"

--- a/i18n/gettext/pt_BR/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/pt_BR/LC_MESSAGES/cinder.po
@@ -195,3 +195,28 @@ msgstr "Digite para pesquisar mais opções..."
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr "Um erro ocorreu ao carregar os dados"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Fechar"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Concluído"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr "Arraste para reordenar"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr "Editar colunas"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr "Restaurar padrões"

--- a/i18n/gettext/sv/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/sv/LC_MESSAGES/cinder.po
@@ -198,3 +198,28 @@ msgstr "Skriv för att söka fler alternativ..."
 #, elixir-autogen, elixir-format
 msgid "An error occurred while loading data"
 msgstr "Ett fel uppstod vid laddning av data"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Stäng"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Klar"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Drag to reorder"
+msgstr "Dra för att ändra ordning"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Edit columns"
+msgstr "Redigera kolumner"
+
+#: lib/cinder/renderers/column_prefs.ex
+#, elixir-autogen, elixir-format
+msgid "Reset to defaults"
+msgstr "Återställ till standard"

--- a/lib/cinder/collection.ex
+++ b/lib/cinder/collection.ex
@@ -237,6 +237,20 @@ defmodule Cinder.Collection do
       "Event name (atom or string) sent to parent when selection changes. Parent receives {event_name, %{selected_ids: MapSet.t(), selected_count: integer(), component_id: string(), action: atom()}}."
   )
 
+  attr(:column_preferences?, :boolean,
+    default: false,
+    doc:
+      "Enable user-editable column visibility and ordering. When true, an \"Edit columns\" control is rendered, prefs are persisted to localStorage by table id, and on_columns_change fires on every change. Requires a stable :id."
+  )
+
+  attr(:on_columns_change, :any,
+    default: nil,
+    doc:
+      "Event name (atom or string) sent to parent when column visibility or order changes. " <>
+        "Parent receives {event_name, %{prefs: %{order: [field], hidden: [field]}, id: string()}}. " <>
+        "Use this to persist preferences server-side instead of (or in addition to) localStorage."
+  )
+
   slot :col do
     attr(:field, :string,
       required: false,
@@ -259,6 +273,21 @@ defmodule Cinder.Collection do
     attr(:search, :boolean, doc: "Enable global search on this column")
     attr(:label, :string, doc: "Custom column label (auto-generated if not provided)")
     attr(:class, :string, doc: "CSS classes for table column (table layout only)")
+
+    attr(:hideable, :boolean,
+      doc:
+        "Whether end users can hide this column via the column-prefs UI. Defaults to true. Set to false for required columns (id, primary identifier, action buttons)."
+    )
+
+    attr(:reorderable, :boolean,
+      doc:
+        "Whether end users can reorder this column via drag. Defaults to true. Set to false to pin a column at its declared position."
+    )
+
+    attr(:default_visible, :boolean,
+      doc:
+        "Whether this column is visible by default. Defaults to true. Set to false to declare a column that ships hidden until the user opts in."
+    )
   end
 
   slot(:item,
@@ -352,6 +381,8 @@ defmodule Cinder.Collection do
       |> assign_new(:url_state, fn -> false end)
       |> assign_new(:query_opts, fn -> [] end)
       |> assign_new(:on_state_change, fn -> nil end)
+      |> assign_new(:column_preferences?, fn -> false end)
+      |> assign_new(:on_columns_change, fn -> nil end)
       |> assign_new(:show_pagination, fn -> true end)
       |> assign(:loading_message, assigns[:loading_message] || dgettext("cinder", "Loading..."))
       |> assign(:filters_label, assigns[:filters_label] || dgettext("cinder", "Filters"))
@@ -493,6 +524,8 @@ defmodule Cinder.Collection do
         id_field={@id_field}
         selectable={@selectable}
         on_selection_change={@on_selection_change}
+        column_preferences?={@column_preferences?}
+        on_columns_change={@on_columns_change}
         bulk_action_slots={@bulk_action_slots}
         sort_mode={@sort_mode}
       />
@@ -601,6 +634,9 @@ defmodule Cinder.Collection do
         filter_fn: parsed_column.filter_fn,
         searchable: parsed_column.searchable,
         sort_cycle: sort_config.cycle || [nil, :asc, :desc],
+        hideable: field != nil && Map.get(slot, :hideable, true),
+        reorderable: field != nil && Map.get(slot, :reorderable, true),
+        default_visible: Map.get(slot, :default_visible, true),
         __slot__: :col
       }
     end)

--- a/lib/cinder/column_preferences.ex
+++ b/lib/cinder/column_preferences.ex
@@ -1,0 +1,163 @@
+defmodule Cinder.ColumnPreferences do
+  @moduledoc """
+  Pure logic for applying user-edited column visibility and ordering.
+
+  Preferences are a `%{order: [field], hidden: MapSet.t(field)}` map. `order`
+  lists reorderable columns in the user's preferred sequence; pinned columns
+  (declared with `reorderable: false`) keep their original declared position.
+  Hidden columns are removed from the rendered list entirely.
+  """
+
+  @type field :: String.t()
+  @type t :: %{order: [field] | nil, hidden: MapSet.t(field)}
+
+  @doc "Empty/default preferences — no hidden columns, no custom order."
+  @spec empty() :: t()
+  def empty, do: %{order: nil, hidden: MapSet.new()}
+
+  @doc """
+  Builds initial preferences from the declared columns.
+
+  Columns with `default_visible: false` are added to `hidden` so the user has
+  to opt them in via the column-prefs UI.
+  """
+  @spec from_columns([map()]) :: t()
+  def from_columns(columns) do
+    hidden =
+      columns
+      |> Enum.filter(fn col ->
+        Map.get(col, :hideable, true) && Map.get(col, :default_visible, true) == false
+      end)
+      |> Enum.map(& &1.field)
+      |> MapSet.new()
+
+    %{order: nil, hidden: hidden}
+  end
+
+  @doc """
+  Returns `columns` with `prefs` applied: hidden columns removed, reorderable
+  columns sorted by `prefs.order`, pinned columns held at their declared index.
+  """
+  @spec apply([map()], t()) :: [map()]
+  def apply(columns, %{hidden: hidden, order: order_opt}) do
+    visible = Enum.reject(columns, &MapSet.member?(hidden, &1.field))
+
+    pinned_with_idx =
+      visible
+      |> Enum.with_index()
+      |> Enum.filter(fn {col, _idx} -> not Map.get(col, :reorderable, true) end)
+      |> Enum.sort_by(fn {_col, idx} -> idx end)
+
+    reorderable = Enum.filter(visible, &Map.get(&1, :reorderable, true))
+
+    ordered_reorderable = order_reorderable(reorderable, order_opt)
+
+    Enum.reduce(pinned_with_idx, ordered_reorderable, fn {col, idx}, acc ->
+      List.insert_at(acc, idx, col)
+    end)
+  end
+
+  @doc """
+  Toggles visibility of a column field, returning new prefs.
+
+  Refuses to hide non-hideable columns. The caller passes the full column list
+  so we can validate.
+  """
+  @spec toggle_hidden(t(), field, [map()]) :: t()
+  def toggle_hidden(prefs, field, columns) do
+    columns
+    |> Enum.find(&(&1.field == field))
+    |> do_toggle_hidden(prefs, field)
+  end
+
+  defp do_toggle_hidden(nil, prefs, _field), do: prefs
+
+  defp do_toggle_hidden(col, prefs, field) do
+    if Map.get(col, :hideable, true) do
+      %{prefs | hidden: toggle_member(prefs.hidden, field)}
+    else
+      prefs
+    end
+  end
+
+  defp toggle_member(set, member) do
+    if MapSet.member?(set, member),
+      do: MapSet.delete(set, member),
+      else: MapSet.put(set, member)
+  end
+
+  @doc """
+  Replaces the order of reorderable columns.
+
+  Filters `new_order` down to the fields of reorderable columns that exist;
+  ignores unknown or pinned fields.
+  """
+  @spec set_order(t(), [field], [map()]) :: t()
+  def set_order(prefs, new_order, columns) when is_list(new_order) do
+    valid_fields =
+      columns
+      |> Enum.filter(&Map.get(&1, :reorderable, true))
+      |> Enum.map(& &1.field)
+      |> MapSet.new()
+
+    cleaned =
+      new_order
+      |> Enum.filter(&MapSet.member?(valid_fields, &1))
+      |> Enum.uniq()
+
+    %{prefs | order: cleaned}
+  end
+
+  @doc "Returns prefs in JSON-friendly form for client persistence."
+  @spec to_payload(t()) :: %{order: [field] | nil, hidden: [field]}
+  def to_payload(%{order: order, hidden: hidden}) do
+    %{order: order, hidden: Enum.sort(MapSet.to_list(hidden))}
+  end
+
+  @doc """
+  Builds prefs from a client-supplied payload, validating fields against `columns`.
+
+  Unknown fields and pinned fields in `order` are dropped. Unknown fields and
+  non-hideable fields in `hidden` are dropped.
+  """
+  @spec from_payload(map() | nil, [map()]) :: t()
+  def from_payload(nil, columns), do: from_columns(columns)
+
+  def from_payload(payload, columns) when is_map(payload) do
+    raw_order = Map.get(payload, "order") || Map.get(payload, :order)
+    raw_hidden = Map.get(payload, "hidden") || Map.get(payload, :hidden) || []
+
+    base = from_columns(columns)
+
+    base = if is_list(raw_order), do: set_order(base, raw_order, columns), else: base
+
+    hideable_fields =
+      columns
+      |> Enum.filter(&Map.get(&1, :hideable, true))
+      |> Enum.map(& &1.field)
+      |> MapSet.new()
+
+    hidden =
+      raw_hidden
+      |> Enum.filter(&MapSet.member?(hideable_fields, &1))
+      |> MapSet.new()
+
+    %{base | hidden: hidden}
+  end
+
+  defp order_reorderable(reorderable, nil), do: reorderable
+
+  defp order_reorderable(reorderable, user_order) when is_list(user_order) do
+    by_field = Map.new(reorderable, &{&1.field, &1})
+
+    from_user =
+      user_order
+      |> Enum.map(&Map.get(by_field, &1))
+      |> Enum.reject(&is_nil/1)
+
+    seen = MapSet.new(from_user, & &1.field)
+    new_cols = Enum.reject(reorderable, &MapSet.member?(seen, &1.field))
+
+    from_user ++ new_cols
+  end
+end

--- a/lib/cinder/live_component.ex
+++ b/lib/cinder/live_component.ex
@@ -96,6 +96,10 @@ defmodule Cinder.LiveComponent do
     do_update_items_if_visible(socket, nil, ids, update_fn, id_field)
   end
 
+  def update(%{__force_hydrate__: true}, socket) do
+    {:ok, force_hydrate_column_prefs(socket)}
+  end
+
   def update(assigns, socket) do
     prev_state = data_state(socket.assigns)
 
@@ -103,6 +107,7 @@ defmodule Cinder.LiveComponent do
       socket
       |> assign(assigns)
       |> assign_defaults()
+      |> maybe_schedule_force_hydrate()
       |> assign_column_definitions()
       |> decode_url_state(assigns)
       |> load_data_if_needed(prev_state)
@@ -350,6 +355,45 @@ defmodule Cinder.LiveComponent do
   end
 
   # ============================================================================
+  # COLUMN PREFERENCES EVENT HANDLERS
+  # ============================================================================
+
+  @impl true
+  def handle_event("toggle_column_visibility", %{"field" => field}, socket) do
+    {:noreply,
+     update_column_prefs(socket, fn prefs ->
+       Cinder.ColumnPreferences.toggle_hidden(prefs, field, socket.assigns.declared_columns)
+     end)}
+  end
+
+  @impl true
+  def handle_event("reorder_columns", %{"order" => new_order}, socket) when is_list(new_order) do
+    {:noreply,
+     update_column_prefs(socket, fn prefs ->
+       Cinder.ColumnPreferences.set_order(prefs, new_order, socket.assigns.declared_columns)
+     end)}
+  end
+
+  @impl true
+  def handle_event("reset_column_preferences", _params, socket) do
+    {:noreply,
+     update_column_prefs(socket, fn _prefs ->
+       Cinder.ColumnPreferences.from_columns(socket.assigns.declared_columns)
+     end)}
+  end
+
+  @impl true
+  def handle_event("apply_column_preferences", payload, socket) do
+    {:noreply, hydrate_column_prefs(socket, payload)}
+  end
+
+  @impl true
+  def handle_event("toggle_column_prefs_drawer", _params, socket) do
+    {:noreply,
+     assign(socket, :column_prefs_drawer_open?, !socket.assigns[:column_prefs_drawer_open?])}
+  end
+
+  # ============================================================================
   # SELECTION EVENT HANDLERS
   # ============================================================================
 
@@ -562,6 +606,30 @@ defmodule Cinder.LiveComponent do
       resource when is_atom(resource) and not is_nil(resource) -> resource
       _ -> nil
     end
+  end
+
+  defp update_column_prefs(socket, prefs_fn) do
+    new_prefs = prefs_fn.(socket.assigns.column_preferences)
+
+    socket
+    |> assign(:column_preferences, new_prefs)
+    |> assign_column_definitions()
+    |> push_column_prefs_to_client(new_prefs)
+    |> maybe_notify_columns_change(new_prefs)
+  end
+
+  defp push_column_prefs_to_client(socket, prefs) do
+    payload = Cinder.ColumnPreferences.to_payload(prefs)
+    push_event(socket, "cinder:column_prefs_changed", Map.put(payload, :id, socket.assigns.id))
+  end
+
+  defp maybe_notify_columns_change(socket, prefs) do
+    if event_name = socket.assigns[:on_columns_change] do
+      payload = %{prefs: Cinder.ColumnPreferences.to_payload(prefs), id: socket.assigns.id}
+      send(self(), {event_name, payload})
+    end
+
+    socket
   end
 
   defp notify_selection_change(socket, action) do
@@ -830,32 +898,111 @@ defmodule Cinder.LiveComponent do
     |> assign(:on_selection_change, assigns[:on_selection_change])
     |> assign(:id_field, assigns[:id_field] || :id)
     |> assign(:sort_mode, assigns[:sort_mode] || :additive)
+    |> assign_column_prefs_defaults(assigns)
     # Bulk actions
     |> assign_new(:bulk_action_slots, fn -> [] end)
   end
 
-  defp assign_column_definitions(socket) do
-    # Display columns - already processed by Collection, use directly
-    columns = socket.assigns.col
-
-    # Query columns - columns used for filtering and searching
-    # Includes filterable columns, searchable columns, and filter-only slots
-    query_columns =
-      case Map.get(socket.assigns, :query_columns) do
-        nil -> columns
-        qc -> qc
-      end
-
-    # Field names of filterable columns (for URL state management)
-    filter_field_names =
-      query_columns
-      |> Enum.filter(& &1.filterable)
-      |> Enum.map(& &1.field)
+  defp assign_column_prefs_defaults(socket, assigns) do
+    prefs_on? = assigns[:column_preferences?] || false
 
     socket
-    |> assign(:columns, columns)
-    |> assign(:query_columns, query_columns)
-    |> assign(:filter_field_names, filter_field_names)
+    |> assign(:column_preferences?, prefs_on?)
+    |> assign(:on_columns_change, assigns[:on_columns_change])
+    |> assign_new(:column_preferences, fn ->
+      Cinder.ColumnPreferences.from_columns(assigns[:col] || [])
+    end)
+    |> assign_new(:column_prefs_drawer_open?, fn -> false end)
+    |> assign_new(:column_prefs_hydrated?, fn -> not prefs_on? end)
+    |> assign_new(:column_prefs_hydrate_scheduled?, fn -> false end)
+  end
+
+  defp hydrate_column_prefs(socket, payload) do
+    prefs = Cinder.ColumnPreferences.from_payload(payload, socket.assigns.declared_columns)
+
+    socket
+    |> assign(:column_preferences, prefs)
+    |> assign(:column_prefs_hydrated?, true)
+    |> assign_column_definitions()
+  end
+
+  defp force_hydrate_column_prefs(
+         %{assigns: %{column_preferences?: true, column_prefs_hydrated?: false}} = socket
+       ) do
+    socket
+    |> assign(:column_prefs_hydrated?, true)
+    |> assign_column_definitions()
+  end
+
+  defp force_hydrate_column_prefs(socket), do: socket
+
+  defp maybe_schedule_force_hydrate(
+         %{
+           assigns: %{
+             column_preferences?: true,
+             column_prefs_hydrated?: false,
+             column_prefs_hydrate_scheduled?: false
+           }
+         } = socket
+       ) do
+    schedule_force_hydrate_when_connected(socket)
+  end
+
+  defp maybe_schedule_force_hydrate(socket), do: socket
+
+  defp schedule_force_hydrate_when_connected(socket) do
+    if Phoenix.LiveView.connected?(socket) do
+      Phoenix.LiveView.send_update_after(
+        __MODULE__,
+        [id: socket.assigns.id, __force_hydrate__: true],
+        1000
+      )
+
+      assign(socket, :column_prefs_hydrate_scheduled?, true)
+    else
+      socket
+    end
+  end
+
+  defp assign_column_definitions(socket) do
+    declared_columns = socket.assigns.col
+    prefs_on? = socket.assigns[:column_preferences?] || false
+    prefs = socket.assigns.column_preferences
+
+    visible = visible_columns(declared_columns, prefs_on?, prefs)
+    drawer = drawer_columns(declared_columns, visible, prefs_on?, prefs)
+    query = query_columns(socket, declared_columns)
+
+    socket
+    |> assign(:declared_columns, declared_columns)
+    |> assign(:columns, visible)
+    |> assign(:prefs_drawer_columns, drawer)
+    |> assign(:query_columns, query)
+    |> assign(:filter_field_names, filterable_field_names(query))
+  end
+
+  defp visible_columns(declared, false, _prefs), do: declared
+  defp visible_columns(declared, true, prefs), do: Cinder.ColumnPreferences.apply(declared, prefs)
+
+  defp drawer_columns(declared, _visible, false, _prefs), do: declared
+
+  defp drawer_columns(declared, visible, true, prefs) do
+    visible ++ Enum.filter(declared, &MapSet.member?(prefs.hidden, &1.field))
+  end
+
+  # Columns used for filtering and searching. Cinder.Collection populates this
+  # to include filter-only slots whose fields aren't visible in the table;
+  # falls back to declared_columns when no separate list was provided.
+  defp query_columns(socket, declared_columns) do
+    Map.get(socket.assigns, :query_columns) || declared_columns
+  end
+
+  # Field names of filterable columns. Consumed by Cinder.UrlManager to know
+  # which keys to read out of URL params when restoring filter state.
+  defp filterable_field_names(query_columns) do
+    query_columns
+    |> Enum.filter(& &1.filterable)
+    |> Enum.map(& &1.field)
   end
 
   defp extract_initial_sorts(assigns) do

--- a/lib/cinder/renderers/column_prefs.ex
+++ b/lib/cinder/renderers/column_prefs.ex
@@ -1,0 +1,203 @@
+defmodule Cinder.Renderers.ColumnPrefs do
+  @moduledoc """
+  Renders the "Edit columns" control: a toggle button, a hydration hook,
+  and a slide-in drawer with checkboxes + drag handles for show/hide and
+  reorder of declared columns.
+
+  Mounted by the table/list/grid renderers when `column_preferences?` is true.
+  """
+
+  use Phoenix.Component
+  use Cinder.Messages
+
+  attr(:id, :string, required: true, doc: "Cinder table id; used as localStorage key")
+  attr(:myself, :any, required: true, doc: "LiveComponent CID for phx-target")
+
+  attr(:enabled, :boolean,
+    default: false,
+    doc: "Master switch — equals @column_preferences? from the parent"
+  )
+
+  attr(:open?, :boolean, default: false, doc: "Whether the drawer is open")
+
+  attr(:drawer_columns, :list,
+    default: [],
+    doc:
+      "Columns to render in the drawer, in display order: visible columns in the user's preferred order followed by hidden columns at the end."
+  )
+
+  attr(:prefs, :map, required: true, doc: "Current %{order, hidden} preferences")
+  attr(:theme, :map, required: true, doc: "Resolved theme map")
+
+  def render(assigns) do
+    ~H"""
+    <div :if={@enabled}
+         class={@theme.column_prefs_container_class}
+         data-key="column_prefs_container_class">
+      <div
+        id={"#{@id}-column-prefs-hook"}
+        phx-hook="CinderColumnPrefs"
+        phx-target={@myself}
+        data-cinder-table-id={@id}
+        class="hidden"
+      />
+
+      <button
+        type="button"
+        phx-click="toggle_column_prefs_drawer"
+        phx-target={@myself}
+        class={@theme.column_prefs_button_class}
+        data-key="column_prefs_button_class"
+        aria-haspopup="dialog"
+        aria-expanded={to_string(@open?)}
+        title={dgettext("cinder", "Edit columns")}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+             stroke-width="1.5" stroke="currentColor"
+             class={@theme.column_prefs_button_icon_class}
+             data-key="column_prefs_button_icon_class">
+          <path stroke-linecap="round" stroke-linejoin="round"
+                d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+        </svg>
+        <span>{dgettext("cinder", "Edit columns")}</span>
+      </button>
+
+      <div
+        class={[
+          @theme.column_prefs_backdrop_class,
+          drawer_backdrop_state_class(@open?)
+        ]}
+        data-key="column_prefs_backdrop_class"
+        phx-click="toggle_column_prefs_drawer"
+        phx-target={@myself}
+        aria-hidden="true"
+      />
+
+      <div class={[
+             @theme.column_prefs_panel_class,
+             drawer_panel_state_class(@open?)
+           ]}
+           data-key="column_prefs_panel_class"
+           role="dialog"
+           aria-modal={to_string(@open?)}
+           aria-label={dgettext("cinder", "Edit columns")}
+           inert={not @open?}>
+          <div class={@theme.column_prefs_header_class}
+               data-key="column_prefs_header_class">
+            <h2 class={@theme.column_prefs_title_class}
+                data-key="column_prefs_title_class">{dgettext("cinder", "Edit columns")}</h2>
+            <button
+              type="button"
+              phx-click="toggle_column_prefs_drawer"
+              phx-target={@myself}
+              class={@theme.column_prefs_close_button_class}
+              data-key="column_prefs_close_button_class"
+              aria-label={dgettext("cinder", "Close")}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                   stroke-width="1.5" stroke="currentColor"
+                   class={@theme.column_prefs_close_icon_class}
+                   data-key="column_prefs_close_icon_class">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <ul
+            id={"#{@id}-column-prefs-list"}
+            phx-hook="CinderColumnSortable"
+            phx-target={@myself}
+            data-cinder-table-id={@id}
+            class={@theme.column_prefs_list_class}
+            data-key="column_prefs_list_class"
+          >
+            <li
+              :for={column <- @drawer_columns}
+              data-field={column.field}
+              data-reorderable={to_string(Map.get(column, :reorderable, true))}
+              class={[
+                @theme.column_prefs_item_class,
+                Map.get(column, :reorderable, true) && @theme.column_prefs_item_reorderable_class,
+                not Map.get(column, :reorderable, true) && @theme.column_prefs_item_pinned_class
+              ]}
+              data-key="column_prefs_item_class"
+            >
+              <span :if={Map.get(column, :reorderable, true)}
+                    class={@theme.column_prefs_drag_handle_class}
+                    data-key="column_prefs_drag_handle_class"
+                    aria-hidden="true"
+                    title={dgettext("cinder", "Drag to reorder")}>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                     fill="currentColor"
+                     class={@theme.column_prefs_drag_handle_icon_class}
+                     data-key="column_prefs_drag_handle_icon_class">
+                  <circle cx="9" cy="6" r="1.5" />
+                  <circle cx="9" cy="12" r="1.5" />
+                  <circle cx="9" cy="18" r="1.5" />
+                  <circle cx="15" cy="6" r="1.5" />
+                  <circle cx="15" cy="12" r="1.5" />
+                  <circle cx="15" cy="18" r="1.5" />
+                </svg>
+              </span>
+              <span :if={not Map.get(column, :reorderable, true)}
+                    class={@theme.column_prefs_pinned_icon_class}
+                    data-key="column_prefs_pinned_icon_class"
+                    aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                     fill="currentColor"
+                     class={@theme.column_prefs_drag_handle_icon_class}
+                     data-key="column_prefs_drag_handle_icon_class">
+                  <path d="M12 2a3 3 0 0 0-3 3v3H6a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-9a2 2 0 0 0-2-2h-3V5a3 3 0 0 0-3-3zm-1 6V5a1 1 0 1 1 2 0v3h-2z" />
+                </svg>
+              </span>
+
+              <input
+                id={"#{@id}-prefs-cb-#{column.field}"}
+                type="checkbox"
+                checked={not MapSet.member?(@prefs.hidden, column.field)}
+                disabled={not Map.get(column, :hideable, true)}
+                phx-click="toggle_column_visibility"
+                phx-value-field={column.field}
+                phx-target={@myself}
+                class={@theme.column_prefs_checkbox_class}
+                data-key="column_prefs_checkbox_class"
+              />
+
+              <label for={"#{@id}-prefs-cb-#{column.field}"}
+                     class={@theme.column_prefs_label_class}
+                     data-key="column_prefs_label_class">{column.label}</label>
+            </li>
+          </ul>
+
+          <div class={@theme.column_prefs_footer_class}
+               data-key="column_prefs_footer_class">
+            <button
+              type="button"
+              phx-click="reset_column_preferences"
+              phx-target={@myself}
+              class={@theme.column_prefs_reset_button_class}
+              data-key="column_prefs_reset_button_class"
+            >
+              {dgettext("cinder", "Reset to defaults")}
+            </button>
+            <button
+              type="button"
+              phx-click="toggle_column_prefs_drawer"
+              phx-target={@myself}
+              class={@theme.column_prefs_done_button_class}
+              data-key="column_prefs_done_button_class"
+            >
+              {dgettext("cinder", "Done")}
+            </button>
+          </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp drawer_panel_state_class(true), do: "translate-x-0"
+  defp drawer_panel_state_class(false), do: "translate-x-full"
+
+  defp drawer_backdrop_state_class(true), do: "opacity-100"
+  defp drawer_backdrop_state_class(false), do: "opacity-0 pointer-events-none"
+end

--- a/lib/cinder/renderers/table.ex
+++ b/lib/cinder/renderers/table.ex
@@ -12,6 +12,7 @@ defmodule Cinder.Renderers.Table do
   import Cinder.Renderers.Helpers
 
   alias Cinder.Renderers.BulkActions
+  alias Cinder.Renderers.ColumnPrefs
   alias Cinder.Renderers.Pagination
 
   @doc """
@@ -39,6 +40,17 @@ defmodule Cinder.Renderers.Table do
         />
       </div>
 
+      <!-- Column preferences (Edit columns) -->
+      <ColumnPrefs.render
+        id={@id}
+        myself={@myself}
+        theme={@theme}
+        enabled={Map.get(assigns, :column_preferences?, false)}
+        open?={Map.get(assigns, :column_prefs_drawer_open?, false)}
+        drawer_columns={Map.get(assigns, :prefs_drawer_columns, Map.get(assigns, :declared_columns, @columns))}
+        prefs={Map.get(assigns, :column_preferences, Cinder.ColumnPreferences.empty())}
+      />
+
       <!-- Bulk Actions -->
       <BulkActions.render
         selectable={@selectable}
@@ -49,7 +61,10 @@ defmodule Cinder.Renderers.Table do
       />
 
       <!-- Main table -->
-      <div class={@theme.table_wrapper_class} data-key="table_wrapper_class">
+      <div class={[
+             @theme.table_wrapper_class,
+             prefs_hydration_class(assigns)
+           ]} data-key="table_wrapper_class">
         <table class={@theme.table_class} data-key="table_class">
           <thead class={@theme.thead_class} data-key="thead_class">
             <tr class={@theme.header_row_class} data-key="header_row_class">
@@ -226,6 +241,11 @@ defmodule Cinder.Renderers.Table do
   end
 
   defp all_page_selected?(_selected_ids, _data, _id_field), do: false
+
+  defp prefs_hydration_class(%{column_preferences?: true, column_prefs_hydrated?: false}),
+    do: "invisible"
+
+  defp prefs_hydration_class(_assigns), do: ""
 
   defp item_selected?(selected_ids, item, id_field) do
     id = to_string(Map.get(item, id_field))

--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -52,6 +52,15 @@ defmodule Cinder.Table do
   attr :url_state, :any, default: false, doc: "URL state object from UrlSync.handle_params"
   attr :query_opts, :list, default: [], doc: "Additional Ash query options"
   attr :on_state_change, :any, default: nil, doc: "Custom state change handler"
+
+  attr :column_preferences?, :boolean,
+    default: false,
+    doc: "Enable end-user column visibility/order editing. See `Cinder.collection`."
+
+  attr :on_columns_change, :any,
+    default: nil,
+    doc: "Event name sent to parent when column prefs change. See `Cinder.collection`."
+
   attr :show_pagination, :boolean, default: true, doc: "Whether to show pagination controls"
   attr :show_filters, :boolean, default: nil, doc: "Whether to show filter controls"
   attr :loading_message, :string, default: nil, doc: "Message to show while loading"
@@ -70,6 +79,9 @@ defmodule Cinder.Table do
     attr :search, :boolean
     attr :label, :string
     attr :class, :string
+    attr :hideable, :boolean
+    attr :reorderable, :boolean
+    attr :default_visible, :boolean
   end
 
   slot :filter do

--- a/lib/cinder/theme.ex
+++ b/lib/cinder/theme.ex
@@ -185,7 +185,37 @@ defmodule Cinder.Theme do
     button_primary_class: "bg-blue-600 text-white hover:bg-blue-700",
     button_secondary_class: "border border-gray-300 text-gray-700 hover:bg-gray-50",
     button_danger_class: "bg-red-600 text-white hover:bg-red-700",
-    button_disabled_class: "opacity-50 cursor-not-allowed"
+    button_disabled_class: "opacity-50 cursor-not-allowed",
+
+    # Column preferences (Edit columns drawer)
+    column_prefs_container_class: "cinder-column-prefs",
+    column_prefs_button_class:
+      "inline-flex items-center gap-1 px-3 py-1.5 text-sm border border-gray-200 rounded text-gray-900 hover:bg-gray-50 dark:bg-gray-800 dark:text-white dark:border-gray-700 dark:hover:bg-gray-700",
+    column_prefs_button_icon_class: "w-4 h-4",
+    column_prefs_backdrop_class:
+      "fixed inset-0 z-40 bg-black/30 transition-opacity duration-300 ease-in-out",
+    column_prefs_panel_class:
+      "fixed top-0 right-0 h-full w-80 max-w-full bg-white text-gray-900 shadow-xl flex flex-col z-50 dark:bg-gray-800 dark:text-white transition-transform duration-300 ease-in-out",
+    column_prefs_header_class:
+      "flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700",
+    column_prefs_title_class: "text-base font-semibold text-gray-900 dark:text-white",
+    column_prefs_close_button_class: "p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700",
+    column_prefs_close_icon_class: "w-5 h-5",
+    column_prefs_list_class: "flex-1 overflow-y-auto py-2",
+    column_prefs_item_class:
+      "flex items-center gap-2 px-4 py-2 border-b border-gray-200 last:border-b-0 dark:border-gray-700",
+    column_prefs_item_reorderable_class: "cursor-grab",
+    column_prefs_item_pinned_class: "opacity-90",
+    column_prefs_drag_handle_class: "cinder-drag-handle text-gray-400 dark:text-gray-500",
+    column_prefs_drag_handle_icon_class: "w-4 h-4",
+    column_prefs_pinned_icon_class: "text-gray-300 w-4 h-4 dark:text-gray-600",
+    column_prefs_checkbox_class: "cursor-pointer disabled:cursor-not-allowed",
+    column_prefs_label_class: "flex-1 text-sm select-none text-gray-900 dark:text-white",
+    column_prefs_footer_class:
+      "border-t border-gray-200 px-4 py-3 flex justify-between dark:border-gray-700",
+    column_prefs_reset_button_class: "text-sm text-gray-600 hover:underline dark:text-gray-400",
+    column_prefs_done_button_class:
+      "text-sm font-medium px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700"
   }
 
   # Re-export the DSL functionality

--- a/lib/cinder/themes/compact.ex
+++ b/lib/cinder/themes/compact.ex
@@ -224,4 +224,29 @@ defmodule Cinder.Themes.Compact do
   set :button_secondary_class, "bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
   set :button_danger_class, "bg-red-600 text-white hover:bg-red-700"
   set :button_disabled_class, "opacity-50 cursor-not-allowed"
+
+  # Column preferences (Edit columns drawer)
+  set :column_prefs_button_class,
+      "inline-flex items-center gap-1 px-2 py-1 text-xs font-medium border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors duration-150"
+
+  set :column_prefs_panel_class,
+      "fixed top-0 right-0 h-full w-80 max-w-full bg-white text-gray-900 border-l border-gray-300 shadow-sm flex flex-col z-50 transition-transform duration-300 ease-in-out"
+
+  set :column_prefs_header_class,
+      "flex items-center justify-between px-3 py-2 border-b border-gray-300"
+
+  set :column_prefs_title_class, "text-sm font-semibold text-gray-900"
+
+  set :column_prefs_item_class,
+      "flex items-center gap-2 px-3 py-2 text-xs border-b border-gray-200 last:border-b-0"
+
+  set :column_prefs_label_class, "flex-1 text-xs select-none text-gray-900"
+
+  set :column_prefs_footer_class,
+      "border-t border-gray-300 px-3 py-2 flex justify-between"
+
+  set :column_prefs_reset_button_class, "text-xs text-gray-600 hover:underline"
+
+  set :column_prefs_done_button_class,
+      "px-2 py-1 text-xs font-medium rounded bg-blue-600 text-white hover:bg-blue-700"
 end

--- a/lib/cinder/themes/daisy_ui.ex
+++ b/lib/cinder/themes/daisy_ui.ex
@@ -175,4 +175,31 @@ defmodule Cinder.Themes.DaisyUI do
   set :button_secondary_class, "btn-neutral"
   set :button_danger_class, "btn-error"
   set :button_disabled_class, "btn-disabled"
+
+  # Column preferences (Edit columns drawer)
+  set :column_prefs_button_class, "btn btn-sm"
+
+  set :column_prefs_panel_class,
+      "fixed top-0 right-0 h-full w-80 max-w-full bg-base-100 text-base-content shadow-2xl flex flex-col z-50 transition-transform duration-300 ease-in-out"
+
+  set :column_prefs_header_class,
+      "flex items-center justify-between px-4 py-3 border-b border-base-300"
+
+  set :column_prefs_title_class, "text-base font-semibold"
+
+  set :column_prefs_close_button_class, "btn btn-ghost btn-sm btn-square"
+
+  set :column_prefs_item_class,
+      "flex items-center gap-2 px-4 py-2 border-b border-base-300 last:border-b-0"
+
+  set :column_prefs_drag_handle_class, "cinder-drag-handle text-base-content/40"
+  set :column_prefs_pinned_icon_class, "text-base-content/30 w-4 h-4"
+  set :column_prefs_checkbox_class, "checkbox checkbox-sm"
+  set :column_prefs_label_class, "flex-1 text-sm select-none"
+
+  set :column_prefs_footer_class,
+      "border-t border-base-300 px-4 py-3 flex justify-between"
+
+  set :column_prefs_reset_button_class, "btn btn-ghost btn-sm"
+  set :column_prefs_done_button_class, "btn btn-primary btn-sm"
 end

--- a/lib/cinder/themes/dark.ex
+++ b/lib/cinder/themes/dark.ex
@@ -237,4 +237,38 @@ defmodule Cinder.Themes.Dark do
 
   set :button_danger_class, "bg-red-600 text-white hover:bg-red-500"
   set :button_disabled_class, "opacity-50 cursor-not-allowed"
+
+  # Column preferences (Edit columns drawer)
+  set :column_prefs_button_class,
+      "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-lg bg-gray-800 text-gray-200 border border-gray-600 hover:bg-gray-700 hover:border-gray-500 transition-colors duration-150"
+
+  set :column_prefs_panel_class,
+      "fixed top-0 right-0 h-full w-80 max-w-full bg-gray-900 text-gray-200 border-l border-gray-700 shadow-2xl flex flex-col z-50 transition-transform duration-300 ease-in-out"
+
+  set :column_prefs_header_class,
+      "flex items-center justify-between px-4 py-3 border-b border-gray-700"
+
+  set :column_prefs_title_class, "text-base font-semibold text-gray-200"
+
+  set :column_prefs_close_button_class,
+      "p-1 rounded hover:bg-gray-800 text-gray-400 hover:text-gray-200"
+
+  set :column_prefs_item_class,
+      "flex items-center gap-2 px-4 py-2 border-b border-gray-700 last:border-b-0"
+
+  set :column_prefs_drag_handle_class, "cinder-drag-handle text-gray-500"
+  set :column_prefs_pinned_icon_class, "text-gray-600 w-4 h-4"
+
+  set :column_prefs_checkbox_class,
+      "h-4 w-4 bg-gray-700 border-gray-600 rounded checked:bg-purple-500 checked:border-purple-500 focus:ring-purple-500 focus:ring-2 cursor-pointer disabled:cursor-not-allowed"
+
+  set :column_prefs_label_class, "flex-1 text-sm select-none text-gray-200"
+
+  set :column_prefs_footer_class,
+      "border-t border-gray-700 px-4 py-3 flex justify-between"
+
+  set :column_prefs_reset_button_class, "text-sm font-medium text-gray-400 hover:text-gray-200"
+
+  set :column_prefs_done_button_class,
+      "px-3 py-1.5 text-sm font-medium rounded-lg bg-purple-600 text-white hover:bg-purple-500 transition-colors duration-150"
 end

--- a/lib/cinder/themes/flowbite.ex
+++ b/lib/cinder/themes/flowbite.ex
@@ -272,4 +272,40 @@ defmodule Cinder.Themes.Flowbite do
       "text-white bg-red-700 hover:bg-red-800 focus:ring-red-300 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
 
   set :button_disabled_class, "opacity-50 cursor-not-allowed"
+
+  # Column preferences (Edit columns drawer)
+  set :column_prefs_button_class,
+      "inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg text-gray-900 bg-white border border-gray-300 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+
+  set :column_prefs_panel_class,
+      "fixed top-0 right-0 h-full w-80 max-w-full bg-white text-gray-900 shadow-xl flex flex-col z-50 dark:bg-gray-800 dark:text-white transition-transform duration-300 ease-in-out"
+
+  set :column_prefs_header_class,
+      "flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700"
+
+  set :column_prefs_title_class, "text-base font-semibold text-gray-900 dark:text-white"
+
+  set :column_prefs_close_button_class,
+      "p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
+
+  set :column_prefs_item_class,
+      "flex items-center gap-2 px-4 py-2 border-b border-gray-200 last:border-b-0 dark:border-gray-700"
+
+  set :column_prefs_label_class, "flex-1 text-sm select-none text-gray-900 dark:text-white"
+
+  set :column_prefs_footer_class,
+      "border-t border-gray-200 px-4 py-3 flex justify-between dark:border-gray-700"
+
+  set :column_prefs_reset_button_class,
+      "text-sm font-medium text-gray-700 hover:underline dark:text-gray-300"
+
+  set :column_prefs_done_button_class,
+      "px-3 py-2 text-sm font-medium text-white bg-blue-700 hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 rounded-lg dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+
+  set :column_prefs_checkbox_class,
+      "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 dark:bg-gray-700 dark:border-gray-600 cursor-pointer disabled:cursor-not-allowed"
+
+  set :column_prefs_drag_handle_class, "cinder-drag-handle text-gray-400 dark:text-gray-500"
+
+  set :column_prefs_pinned_icon_class, "text-gray-300 w-4 h-4 dark:text-gray-600"
 end

--- a/lib/cinder/themes/futuristic.ex
+++ b/lib/cinder/themes/futuristic.ex
@@ -265,4 +265,39 @@ defmodule Cinder.Themes.Futuristic do
       "bg-red-500/20 border-red-500 text-red-400 hover:bg-red-500/30 hover:shadow-red-500/20 hover:shadow-lg"
 
   set :button_disabled_class, "opacity-50 cursor-not-allowed"
+
+  # Column preferences (Edit columns drawer)
+  set :column_prefs_button_class,
+      "inline-flex items-center gap-1 px-4 py-2 text-sm font-light tracking-wide border border-blue-500/40 bg-slate-900/60 text-blue-100 hover:border-green-400/60 hover:bg-slate-800/60 transition-all duration-300 backdrop-blur-sm"
+
+  set :column_prefs_panel_class,
+      "fixed top-0 right-0 h-full w-80 max-w-full bg-slate-950 text-blue-100 border-l border-blue-500/30 shadow-2xl shadow-blue-500/10 flex flex-col z-50 backdrop-blur-sm transition-transform duration-500 ease-in-out"
+
+  set :column_prefs_header_class,
+      "flex items-center justify-between px-4 py-3 border-b border-blue-500/30"
+
+  set :column_prefs_title_class, "text-base font-light tracking-wider text-blue-100"
+
+  set :column_prefs_close_button_class,
+      "p-1 text-blue-100/70 hover:text-green-400 transition-colors duration-300"
+
+  set :column_prefs_item_class,
+      "flex items-center gap-2 px-4 py-2 border-b border-blue-500/20 last:border-b-0"
+
+  set :column_prefs_drag_handle_class, "cinder-drag-handle text-blue-500/60"
+  set :column_prefs_pinned_icon_class, "text-slate-500 w-4 h-4"
+
+  set :column_prefs_checkbox_class,
+      "h-4 w-4 bg-slate-900 border-blue-500/40 checked:bg-green-500 checked:border-green-400 focus:ring-green-400 focus:ring-1 cursor-pointer disabled:cursor-not-allowed"
+
+  set :column_prefs_label_class, "flex-1 text-sm font-light text-blue-100 select-none"
+
+  set :column_prefs_footer_class,
+      "border-t border-blue-500/30 px-4 py-3 flex justify-between"
+
+  set :column_prefs_reset_button_class,
+      "text-sm font-light text-blue-100/70 hover:text-green-400 transition-colors duration-300"
+
+  set :column_prefs_done_button_class,
+      "px-4 py-2 text-sm font-light tracking-wide border border-green-500 bg-green-500/20 text-green-400 hover:bg-green-500/30 hover:shadow-green-500/20 hover:shadow-lg transition-all duration-300"
 end

--- a/lib/cinder/themes/modern.ex
+++ b/lib/cinder/themes/modern.ex
@@ -223,4 +223,11 @@ defmodule Cinder.Themes.Modern do
   set :button_secondary_class, "bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
   set :button_danger_class, "bg-red-600 text-white hover:bg-red-700"
   set :button_disabled_class, "opacity-50 cursor-not-allowed"
+
+  # Column preferences (Edit columns drawer)
+  set :column_prefs_button_class,
+      "inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors duration-150"
+
+  set :column_prefs_done_button_class,
+      "px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-150"
 end

--- a/lib/cinder/themes/retro.ex
+++ b/lib/cinder/themes/retro.ex
@@ -263,4 +263,40 @@ defmodule Cinder.Themes.Retro do
       "bg-red-500 border-red-400 text-white hover:bg-red-400 hover:shadow-red-400/50 hover:shadow-lg"
 
   set :button_disabled_class, "opacity-50 cursor-not-allowed"
+
+  # Column preferences (Edit columns drawer)
+  set :column_prefs_button_class,
+      "inline-flex items-center gap-1 px-4 py-2 text-sm font-bold uppercase tracking-wide border-2 border-cyan-400 bg-gray-800 text-cyan-100 hover:bg-cyan-400/20 transition-all duration-150"
+
+  set :column_prefs_panel_class,
+      "fixed top-0 right-0 h-full w-80 max-w-full bg-gray-900 text-cyan-100 border-l-2 border-cyan-400 shadow-2xl shadow-cyan-400/20 flex flex-col z-50 transition-transform duration-300 ease-in-out"
+
+  set :column_prefs_header_class,
+      "flex items-center justify-between px-4 py-3 border-b-2 border-cyan-400"
+
+  set :column_prefs_title_class, "text-base font-bold uppercase tracking-widest text-cyan-100"
+
+  set :column_prefs_close_button_class,
+      "p-1 text-cyan-100 hover:text-yellow-400 transition-colors duration-150"
+
+  set :column_prefs_item_class,
+      "flex items-center gap-2 px-4 py-2 border-b border-cyan-400/40 last:border-b-0"
+
+  set :column_prefs_drag_handle_class, "cinder-drag-handle text-cyan-400/70"
+  set :column_prefs_pinned_icon_class, "text-cyan-400/40 w-4 h-4"
+
+  set :column_prefs_checkbox_class,
+      "h-4 w-4 bg-gray-800 border-2 border-cyan-400 checked:bg-fuchsia-500 checked:border-fuchsia-400 focus:ring-fuchsia-400 focus:ring-1 cursor-pointer disabled:cursor-not-allowed"
+
+  set :column_prefs_label_class,
+      "flex-1 text-sm font-bold uppercase tracking-wide text-cyan-100 select-none"
+
+  set :column_prefs_footer_class,
+      "border-t-2 border-cyan-400 px-4 py-3 flex justify-between"
+
+  set :column_prefs_reset_button_class,
+      "text-sm font-bold uppercase text-cyan-100 hover:text-yellow-400 transition-colors duration-150"
+
+  set :column_prefs_done_button_class,
+      "px-4 py-2 text-sm font-bold uppercase tracking-wide border-2 border-cyan-400 bg-fuchsia-500 text-white hover:bg-fuchsia-400 hover:shadow-fuchsia-400/50 hover:shadow-lg transition-all duration-150"
 end

--- a/lib/mix/tasks/cinder.install.ex
+++ b/lib/mix/tasks/cinder.install.ex
@@ -72,6 +72,7 @@ if Code.ensure_loaded?(Igniter) do
       |> Igniter.Project.Formatter.import_dep(:cinder)
       |> configure_tailwind()
       |> configure_default_theme()
+      |> configure_js_hooks()
     end
 
     @tailwind_v3_prefix """
@@ -211,6 +212,109 @@ if Code.ensure_loaded?(Igniter) do
           "modern"
         )
       end
+    end
+
+    # Auto-patches assets/package.json with the npm deps; emits a notice
+    # for the app.js wireup since that's too varied to patch reliably.
+    defp configure_js_hooks(igniter) do
+      if Igniter.exists?(igniter, "assets/package.json") do
+        igniter
+        |> ensure_js_dependency("cinder", "file:../deps/cinder/assets")
+        |> ensure_js_dependency("sortablejs", "^1.15.0")
+        |> add_app_js_notice()
+      else
+        igniter
+      end
+    end
+
+    defp ensure_js_dependency(igniter, name, version) do
+      igniter = Igniter.include_glob(igniter, "assets/package.json")
+      source = Rewrite.source!(igniter.rewrite, "assets/package.json")
+      content = Rewrite.Source.get(source, :content)
+
+      cond do
+        already_declared?(content, name) ->
+          igniter
+
+        has_dependencies_block?(content) ->
+          inject_dep(igniter, source, content, name, version)
+
+        true ->
+          Igniter.add_notice(igniter, missing_deps_block_notice())
+      end
+    end
+
+    defp already_declared?(content, name) do
+      Regex.match?(~r/"#{Regex.escape(name)}"\s*:/, content)
+    end
+
+    defp has_dependencies_block?(content) do
+      Regex.match?(~r/"dependencies"\s*:\s*\{/, content)
+    end
+
+    defp missing_deps_block_notice do
+      """
+      Cinder JS Setup:
+
+      Could not find a "dependencies" block in assets/package.json. Add
+      these entries manually so Cinder's hooks (and drag-to-reorder)
+      can be wired into your bundler:
+
+          "cinder": "file:../deps/cinder/assets",
+          "sortablejs": "^1.15.0"
+
+      Then run `npm install` (or `pnpm install` / `yarn`).
+      """
+    end
+
+    defp inject_dep(igniter, source, content, name, version) do
+      updated = inject_into_dependencies(content, name, version)
+      source = Rewrite.Source.update(source, :content, updated)
+      %{igniter | rewrite: Rewrite.update!(igniter.rewrite, source)}
+    end
+
+    @doc false
+    def inject_into_dependencies(content, name, version) do
+      [head, rest] = Regex.split(~r/"dependencies"\s*:\s*\{/, content, parts: 2)
+      opener = Regex.run(~r/"dependencies"\s*:\s*\{/, content) |> List.first()
+      indent = detect_indent(rest)
+      new_line = ~s(#{indent}"#{name}": "#{version}",\n)
+      head <> opener <> "\n" <> new_line <> String.trim_leading(rest, "\n")
+    end
+
+    defp detect_indent(rest) do
+      case Regex.run(~r/\n([ \t]+)"/, rest) do
+        [_, ws] -> ws
+        _ -> "    "
+      end
+    end
+
+    defp add_app_js_notice(igniter) do
+      Igniter.add_notice(igniter, """
+      Cinder JS Hooks — Manual app.js Step:
+
+      Cinder's column-preferences feature uses LiveView hooks for localStorage
+      persistence and drag-to-reorder. We've added `cinder` and `sortablejs`
+      to your assets/package.json. After `npm install` (or pnpm/yarn), wire
+      the hooks into assets/js/app.js:
+
+          import { createCinderHooks } from "cinder"
+          import Sortable from "sortablejs"
+
+          let liveSocket = new LiveSocket("/live", Socket, {
+            // ...
+            hooks: {
+              ...createCinderHooks({ Sortable }),
+              // ...your existing hooks
+            }
+          })
+
+      The hooks are no-op when no Cinder table on the page uses
+      `column_preferences?`, so this addition is safe even if you don't use
+      that feature yet. The Sortable import is only needed for
+      drag-to-reorder; column visibility (checkboxes) and localStorage
+      persistence work without it.
+      """)
     end
   end
 else

--- a/test/cinder/column_preferences_live_component_test.exs
+++ b/test/cinder/column_preferences_live_component_test.exs
@@ -1,0 +1,246 @@
+defmodule Cinder.ColumnPreferencesLiveComponentTest do
+  @moduledoc """
+  Integration tests for column-preferences events on the LiveComponent.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Cinder.{ColumnPreferences, LiveComponent}
+
+  defp col(field, opts \\ []) do
+    %{
+      field: field,
+      label: field,
+      hideable: Keyword.get(opts, :hideable, true),
+      reorderable: Keyword.get(opts, :reorderable, true),
+      default_visible: Keyword.get(opts, :default_visible, true),
+      filterable: false,
+      sortable: false,
+      class: ""
+    }
+  end
+
+  defp make_socket(opts) do
+    declared = Keyword.fetch!(opts, :columns)
+
+    assigns =
+      %{
+        __changed__: %{},
+        id: Keyword.get(opts, :id, "test-table"),
+        col: declared,
+        declared_columns: declared,
+        columns: declared,
+        column_preferences?: Keyword.get(opts, :column_preferences?, true),
+        column_preferences:
+          Keyword.get(opts, :column_preferences, ColumnPreferences.from_columns(declared)),
+        on_columns_change: Keyword.get(opts, :on_columns_change, nil),
+        column_prefs_drawer_open?: false,
+        column_prefs_hydrated?: Keyword.get(opts, :column_prefs_hydrated?, false),
+        query_columns: declared,
+        filter_field_names: []
+      }
+
+    %Phoenix.LiveView.Socket{assigns: assigns, root_pid: self()}
+  end
+
+  describe "toggle_column_visibility" do
+    test "hides a previously visible hideable column" do
+      cols = [col("a"), col("b"), col("c")]
+      socket = make_socket(columns: cols)
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("toggle_column_visibility", %{"field" => "b"}, socket)
+
+      assert MapSet.member?(socket.assigns.column_preferences.hidden, "b")
+      assert Enum.map(socket.assigns.columns, & &1.field) == ["a", "c"]
+    end
+
+    test "refuses to hide a non-hideable column" do
+      cols = [col("a", hideable: false), col("b")]
+      socket = make_socket(columns: cols)
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("toggle_column_visibility", %{"field" => "a"}, socket)
+
+      assert socket.assigns.column_preferences.hidden == MapSet.new()
+      assert Enum.map(socket.assigns.columns, & &1.field) == ["a", "b"]
+    end
+  end
+
+  describe "reorder_columns" do
+    test "applies new order to reorderable columns" do
+      cols = [col("a"), col("b"), col("c")]
+      socket = make_socket(columns: cols)
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("reorder_columns", %{"order" => ["c", "a", "b"]}, socket)
+
+      assert socket.assigns.column_preferences.order == ["c", "a", "b"]
+      assert Enum.map(socket.assigns.columns, & &1.field) == ["c", "a", "b"]
+    end
+
+    test "preserves pinned column positions" do
+      cols = [col("a"), col("b", reorderable: false), col("c"), col("d")]
+      socket = make_socket(columns: cols)
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("reorder_columns", %{"order" => ["d", "c", "a"]}, socket)
+
+      assert Enum.map(socket.assigns.columns, & &1.field) == ["d", "b", "c", "a"]
+    end
+
+    test "drawer column list mirrors the user's order, with hidden cols at end" do
+      cols = [col("a"), col("b"), col("c"), col("d")]
+
+      socket =
+        make_socket(
+          columns: cols,
+          column_preferences: %{order: nil, hidden: MapSet.new(["c"])}
+        )
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("reorder_columns", %{"order" => ["d", "a", "b"]}, socket)
+
+      drawer_fields = Enum.map(socket.assigns.prefs_drawer_columns, & &1.field)
+      assert drawer_fields == ["d", "a", "b", "c"]
+    end
+  end
+
+  describe "reset_column_preferences" do
+    test "restores defaults" do
+      cols = [col("a"), col("b"), col("c", default_visible: false)]
+
+      socket =
+        make_socket(
+          columns: cols,
+          column_preferences: %{order: ["b", "a"], hidden: MapSet.new(["a"])}
+        )
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("reset_column_preferences", %{}, socket)
+
+      assert socket.assigns.column_preferences == %{order: nil, hidden: MapSet.new(["c"])}
+      assert Enum.map(socket.assigns.columns, & &1.field) == ["a", "b"]
+    end
+  end
+
+  describe "apply_column_preferences (client hydration)" do
+    test "applies payload from localStorage without firing on_columns_change" do
+      cols = [col("a"), col("b"), col("c")]
+      socket = make_socket(columns: cols, on_columns_change: :columns_changed)
+
+      payload = %{"order" => ["c", "b", "a"], "hidden" => ["b"]}
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("apply_column_preferences", payload, socket)
+
+      assert socket.assigns.column_preferences.order == ["c", "b", "a"]
+      assert socket.assigns.column_preferences.hidden == MapSet.new(["b"])
+      assert Enum.map(socket.assigns.columns, & &1.field) == ["c", "a"]
+
+      refute_received {:columns_changed, _}
+    end
+
+    test "marks the table as hydrated even when the payload is empty" do
+      cols = [col("a"), col("b")]
+      socket = make_socket(columns: cols)
+      refute socket.assigns.column_prefs_hydrated?
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("apply_column_preferences", %{}, socket)
+
+      assert socket.assigns.column_prefs_hydrated?
+    end
+
+    test "is idempotent — replaying the same push leaves state coherent" do
+      cols = [col("a"), col("b"), col("c")]
+      socket = make_socket(columns: cols)
+      payload = %{"order" => ["b", "a", "c"], "hidden" => ["c"]}
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("apply_column_preferences", payload, socket)
+
+      first_visible = Enum.map(socket.assigns.columns, & &1.field)
+      first_drawer = Enum.map(socket.assigns.prefs_drawer_columns, & &1.field)
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("apply_column_preferences", payload, socket)
+
+      assert Enum.map(socket.assigns.columns, & &1.field) == first_visible
+      assert Enum.map(socket.assigns.prefs_drawer_columns, & &1.field) == first_drawer
+      assert socket.assigns.column_prefs_hydrated?
+    end
+  end
+
+  describe "force-hydrate fallback" do
+    test "force-hydrate update flips hydrated when prefs hadn't been applied yet" do
+      cols = [col("a"), col("b")]
+      socket = make_socket(columns: cols)
+      refute socket.assigns.column_prefs_hydrated?
+
+      {:ok, socket} = LiveComponent.update(%{__force_hydrate__: true}, socket)
+
+      assert socket.assigns.column_prefs_hydrated?
+      assert Enum.map(socket.assigns.columns, & &1.field) == ["a", "b"]
+    end
+
+    test "force-hydrate update is a no-op when already hydrated" do
+      cols = [col("a"), col("b")]
+      socket = make_socket(columns: cols, column_prefs_hydrated?: true)
+
+      {:ok, socket} = LiveComponent.update(%{__force_hydrate__: true}, socket)
+
+      assert socket.assigns.column_prefs_hydrated?
+    end
+
+    test "force-hydrate update is a no-op when prefs feature is disabled" do
+      cols = [col("a"), col("b")]
+      socket = make_socket(columns: cols, column_preferences?: false)
+
+      {:ok, socket} = LiveComponent.update(%{__force_hydrate__: true}, socket)
+
+      refute socket.assigns.column_prefs_hydrated?
+    end
+  end
+
+  describe "on_columns_change callback" do
+    test "fires after a user edit with payload shape {prefs, id}" do
+      cols = [col("a"), col("b")]
+      socket = make_socket(columns: cols, on_columns_change: :columns_changed)
+
+      {:noreply, _socket} =
+        LiveComponent.handle_event("toggle_column_visibility", %{"field" => "a"}, socket)
+
+      assert_received {:columns_changed, %{prefs: prefs, id: "test-table"}}
+      assert prefs.hidden == ["a"]
+      assert prefs.order == nil
+    end
+
+    test "does not fire when on_columns_change is nil" do
+      cols = [col("a"), col("b")]
+      socket = make_socket(columns: cols, on_columns_change: nil)
+
+      {:noreply, _socket} =
+        LiveComponent.handle_event("reorder_columns", %{"order" => ["b", "a"]}, socket)
+
+      refute_received {_, _}
+    end
+  end
+
+  describe "toggle_column_prefs_drawer" do
+    test "flips the drawer open/closed flag" do
+      cols = [col("a")]
+      socket = make_socket(columns: cols)
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("toggle_column_prefs_drawer", %{}, socket)
+
+      assert socket.assigns.column_prefs_drawer_open? == true
+
+      {:noreply, socket} =
+        LiveComponent.handle_event("toggle_column_prefs_drawer", %{}, socket)
+
+      assert socket.assigns.column_prefs_drawer_open? == false
+    end
+  end
+end

--- a/test/cinder/column_preferences_test.exs
+++ b/test/cinder/column_preferences_test.exs
@@ -1,0 +1,187 @@
+defmodule Cinder.ColumnPreferencesTest do
+  use ExUnit.Case, async: true
+
+  alias Cinder.ColumnPreferences
+
+  defp col(field, opts \\ []) do
+    %{
+      field: field,
+      label: field,
+      hideable: Keyword.get(opts, :hideable, true),
+      reorderable: Keyword.get(opts, :reorderable, true),
+      default_visible: Keyword.get(opts, :default_visible, true)
+    }
+  end
+
+  describe "from_columns/1" do
+    test "starts with no hidden columns and no custom order" do
+      cols = [col("a"), col("b"), col("c")]
+      assert ColumnPreferences.from_columns(cols) == %{order: nil, hidden: MapSet.new()}
+    end
+
+    test "adds default_visible: false hideable columns to hidden" do
+      cols = [col("a"), col("b", default_visible: false), col("c")]
+      assert ColumnPreferences.from_columns(cols).hidden == MapSet.new(["b"])
+    end
+
+    test "ignores default_visible: false on non-hideable columns" do
+      # A column declared as not hideable but with default_visible: false would
+      # be permanently invisible — silently force it visible instead.
+      cols = [col("a"), col("b", hideable: false, default_visible: false)]
+      assert ColumnPreferences.from_columns(cols).hidden == MapSet.new()
+    end
+  end
+
+  describe "apply/2" do
+    test "returns columns unchanged when prefs are empty" do
+      cols = [col("a"), col("b"), col("c")]
+      assert ColumnPreferences.apply(cols, ColumnPreferences.empty()) == cols
+    end
+
+    test "removes hidden columns" do
+      cols = [col("a"), col("b"), col("c")]
+      prefs = %{order: nil, hidden: MapSet.new(["b"])}
+      result = ColumnPreferences.apply(cols, prefs)
+      assert Enum.map(result, & &1.field) == ["a", "c"]
+    end
+
+    test "reorders reorderable columns by user order" do
+      cols = [col("a"), col("b"), col("c")]
+      prefs = %{order: ["c", "a", "b"], hidden: MapSet.new()}
+      result = ColumnPreferences.apply(cols, prefs)
+      assert Enum.map(result, & &1.field) == ["c", "a", "b"]
+    end
+
+    test "pinned columns stay at their declared positions" do
+      cols = [
+        col("a"),
+        col("b", reorderable: false),
+        col("c"),
+        col("d"),
+        col("e", reorderable: false)
+      ]
+
+      # User reorders the reorderables: d, c, a
+      prefs = %{order: ["d", "c", "a"], hidden: MapSet.new()}
+      result = ColumnPreferences.apply(cols, prefs)
+      assert Enum.map(result, & &1.field) == ["d", "b", "c", "a", "e"]
+    end
+
+    test "pinned columns survive when reorderable columns are hidden" do
+      cols = [
+        col("a"),
+        col("b", reorderable: false),
+        col("c"),
+        col("d"),
+        col("e", reorderable: false)
+      ]
+
+      # Hide d, reorder remaining reorderables to [c, a]
+      prefs = %{order: ["c", "a"], hidden: MapSet.new(["d"])}
+      result = ColumnPreferences.apply(cols, prefs)
+      assert Enum.map(result, & &1.field) == ["c", "b", "a", "e"]
+    end
+
+    test "appends new reorderable columns not present in saved order" do
+      # Simulates user has saved order [a, b], then host app adds column c.
+      cols = [col("a"), col("b"), col("c")]
+      prefs = %{order: ["b", "a"], hidden: MapSet.new()}
+      result = ColumnPreferences.apply(cols, prefs)
+      assert Enum.map(result, & &1.field) == ["b", "a", "c"]
+    end
+
+    test "ignores unknown fields in saved order" do
+      cols = [col("a"), col("b")]
+      prefs = %{order: ["b", "phantom", "a"], hidden: MapSet.new()}
+      result = ColumnPreferences.apply(cols, prefs)
+      assert Enum.map(result, & &1.field) == ["b", "a"]
+    end
+  end
+
+  describe "toggle_hidden/3" do
+    test "hides a previously visible hideable column" do
+      cols = [col("a"), col("b")]
+      prefs = ColumnPreferences.empty()
+      result = ColumnPreferences.toggle_hidden(prefs, "a", cols)
+      assert result.hidden == MapSet.new(["a"])
+    end
+
+    test "unhides a hidden column" do
+      cols = [col("a"), col("b")]
+      prefs = %{order: nil, hidden: MapSet.new(["a"])}
+      result = ColumnPreferences.toggle_hidden(prefs, "a", cols)
+      assert result.hidden == MapSet.new()
+    end
+
+    test "refuses to hide a non-hideable column" do
+      cols = [col("a", hideable: false), col("b")]
+      prefs = ColumnPreferences.empty()
+      result = ColumnPreferences.toggle_hidden(prefs, "a", cols)
+      assert result == prefs
+    end
+
+    test "ignores unknown fields" do
+      cols = [col("a")]
+      prefs = ColumnPreferences.empty()
+      assert ColumnPreferences.toggle_hidden(prefs, "phantom", cols) == prefs
+    end
+  end
+
+  describe "set_order/3" do
+    test "stores cleaned order" do
+      cols = [col("a"), col("b"), col("c")]
+      prefs = ColumnPreferences.set_order(ColumnPreferences.empty(), ["c", "b", "a"], cols)
+      assert prefs.order == ["c", "b", "a"]
+    end
+
+    test "drops unknown fields" do
+      cols = [col("a"), col("b")]
+      prefs = ColumnPreferences.set_order(ColumnPreferences.empty(), ["b", "phantom", "a"], cols)
+      assert prefs.order == ["b", "a"]
+    end
+
+    test "drops pinned fields from order" do
+      cols = [col("a"), col("b", reorderable: false), col("c")]
+      prefs = ColumnPreferences.set_order(ColumnPreferences.empty(), ["c", "b", "a"], cols)
+      assert prefs.order == ["c", "a"]
+    end
+
+    test "deduplicates" do
+      cols = [col("a"), col("b")]
+      prefs = ColumnPreferences.set_order(ColumnPreferences.empty(), ["a", "b", "a"], cols)
+      assert prefs.order == ["a", "b"]
+    end
+  end
+
+  describe "from_payload/2" do
+    test "round-trips through to_payload" do
+      cols = [col("a"), col("b"), col("c")]
+      prefs = %{order: ["c", "a", "b"], hidden: MapSet.new(["b"])}
+      payload = ColumnPreferences.to_payload(prefs)
+      result = ColumnPreferences.from_payload(payload, cols)
+      assert result.order == ["c", "a", "b"]
+      assert result.hidden == MapSet.new(["b"])
+    end
+
+    test "accepts string-keyed payload (from JS hook)" do
+      cols = [col("a"), col("b")]
+      payload = %{"order" => ["b", "a"], "hidden" => ["a"]}
+      result = ColumnPreferences.from_payload(payload, cols)
+      assert result.order == ["b", "a"]
+      assert result.hidden == MapSet.new(["a"])
+    end
+
+    test "drops attempts to hide non-hideable columns from a malicious/stale payload" do
+      cols = [col("a", hideable: false), col("b")]
+      payload = %{"order" => [], "hidden" => ["a", "b"]}
+      result = ColumnPreferences.from_payload(payload, cols)
+      assert result.hidden == MapSet.new(["b"])
+    end
+
+    test "nil payload yields defaults" do
+      cols = [col("a"), col("b", default_visible: false)]
+      result = ColumnPreferences.from_payload(nil, cols)
+      assert result.hidden == MapSet.new(["b"])
+    end
+  end
+end

--- a/test/cinder/column_prefs_render_test.exs
+++ b/test/cinder/column_prefs_render_test.exs
@@ -1,0 +1,298 @@
+defmodule Cinder.ColumnPrefsRenderTest do
+  @moduledoc """
+  Render-level tests for the column-prefs drawer UI.
+
+  Hits two layers:
+    * `Cinder.Renderers.ColumnPrefs.render/1` directly — for the drawer content
+      that depends on internal `open?` state we can't reach through the public
+      collection component without a full LV mount.
+    * `Cinder.Collection.collection/1` via `render_component` — for the
+      "Edit columns" button being present (or absent) based on the public attrs.
+  """
+
+  use ExUnit.Case, async: true
+  import Phoenix.LiveViewTest
+
+  alias Cinder.{ColumnPreferences, Theme}
+  alias Cinder.Renderers.ColumnPrefs
+
+  defmodule TestUser do
+    use Ash.Resource,
+      domain: nil,
+      data_layer: Ash.DataLayer.Ets,
+      validate_domain_inclusion?: false
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string)
+      attribute(:email, :string)
+      attribute(:archived_at, :utc_datetime)
+    end
+
+    actions do
+      defaults([:create, :read, :update, :destroy])
+    end
+  end
+
+  defp col(field, opts \\ []) do
+    %{
+      field: field,
+      label: Keyword.get(opts, :label, field),
+      hideable: Keyword.get(opts, :hideable, true),
+      reorderable: Keyword.get(opts, :reorderable, true),
+      default_visible: Keyword.get(opts, :default_visible, true),
+      filterable: false,
+      sortable: false,
+      class: ""
+    }
+  end
+
+  describe "ColumnPrefs.render/1 — closed drawer" do
+    test "renders the toggle button and the hydration hook" do
+      assigns = %{
+        id: "users",
+        myself: 1,
+        theme: Theme.default(),
+        enabled: true,
+        open?: false,
+        drawer_columns: [col("name"), col("email")],
+        prefs: ColumnPreferences.empty()
+      }
+
+      html = render_component(&ColumnPrefs.render/1, assigns)
+
+      assert html =~ "users-column-prefs-hook"
+      assert html =~ ~s(phx-hook="CinderColumnPrefs")
+      assert html =~ "Edit columns"
+      assert html =~ ~s(phx-click="toggle_column_prefs_drawer")
+
+      assert html =~ ~s(data-key="column_prefs_panel_class")
+      assert html =~ "translate-x-full"
+      refute html =~ "translate-x-0"
+      assert html =~ ~s(aria-modal="false")
+      assert html =~ "inert"
+
+      assert html =~ "opacity-0"
+      assert html =~ "pointer-events-none"
+    end
+
+    test "open drawer drops translate-x-full and gains aria-modal=true" do
+      assigns = %{
+        id: "users",
+        myself: 1,
+        theme: Theme.default(),
+        enabled: true,
+        open?: true,
+        drawer_columns: [col("name")],
+        prefs: ColumnPreferences.empty()
+      }
+
+      html = render_component(&ColumnPrefs.render/1, assigns)
+
+      assert html =~ "translate-x-0"
+      refute html =~ "translate-x-full"
+      assert html =~ ~s(aria-modal="true")
+      refute html =~ ~r/\sinert(=|\s|>)/
+    end
+
+    test "renders nothing when disabled" do
+      assigns = %{
+        id: "users",
+        myself: 1,
+        theme: Theme.default(),
+        enabled: false,
+        open?: false,
+        drawer_columns: [col("name")],
+        prefs: ColumnPreferences.empty()
+      }
+
+      html = render_component(&ColumnPrefs.render/1, assigns)
+
+      refute html =~ "Edit columns"
+      refute html =~ "users-column-prefs-hook"
+    end
+
+    test "honors theme classes" do
+      theme =
+        Theme.default()
+        |> Map.put(:column_prefs_button_class, "custom-prefs-btn-xyz")
+
+      assigns = %{
+        id: "users",
+        myself: 1,
+        theme: theme,
+        enabled: true,
+        open?: false,
+        drawer_columns: [col("name")],
+        prefs: ColumnPreferences.empty()
+      }
+
+      html = render_component(&ColumnPrefs.render/1, assigns)
+
+      assert html =~ "custom-prefs-btn-xyz"
+      assert html =~ ~s(data-key="column_prefs_button_class")
+    end
+  end
+
+  describe "ColumnPrefs.render/1 — open drawer" do
+    test "renders one row per declared column with its label" do
+      assigns = %{
+        id: "users",
+        myself: 1,
+        theme: Theme.default(),
+        enabled: true,
+        open?: true,
+        drawer_columns: [col("name", label: "Name"), col("email", label: "Email")],
+        prefs: ColumnPreferences.empty()
+      }
+
+      html = render_component(&ColumnPrefs.render/1, assigns)
+
+      assert html =~ "users-column-prefs-list"
+      assert html =~ ~s(phx-hook="CinderColumnSortable")
+      assert html =~ ~s(data-field="name")
+      assert html =~ ~s(data-field="email")
+      assert html =~ "Reset to defaults"
+      assert html =~ "Done"
+    end
+
+    test "checkbox is unchecked for hidden columns and disabled for non-hideable ones" do
+      hidden_prefs = %{order: nil, hidden: MapSet.new(["email"])}
+
+      assigns = %{
+        id: "users",
+        myself: 1,
+        theme: Theme.default(),
+        enabled: true,
+        open?: true,
+        drawer_columns: [col("id", hideable: false), col("name"), col("email")],
+        prefs: hidden_prefs
+      }
+
+      html = render_component(&ColumnPrefs.render/1, assigns)
+
+      [id_row] = Regex.run(~r/<li[^>]*data-field="id"[\s\S]*?<\/li>/, html)
+      [name_row] = Regex.run(~r/<li[^>]*data-field="name"[\s\S]*?<\/li>/, html)
+      [email_row] = Regex.run(~r/<li[^>]*data-field="email"[\s\S]*?<\/li>/, html)
+
+      assert Regex.match?(~r/<input[^>]*\schecked[\s>]/, id_row)
+      assert Regex.match?(~r/<input[^>]*\sdisabled[\s>]/, id_row)
+
+      assert Regex.match?(~r/<input[^>]*\schecked[\s>]/, name_row)
+      refute Regex.match?(~r/<input[^>]*\sdisabled[\s>]/, name_row)
+
+      refute Regex.match?(~r/<input[^>]*\schecked[\s>]/, email_row)
+    end
+
+    test "non-reorderable columns get the pinned indicator and no drag handle" do
+      assigns = %{
+        id: "users",
+        myself: 1,
+        theme: Theme.default(),
+        enabled: true,
+        open?: true,
+        drawer_columns: [col("name"), col("actions", reorderable: false)],
+        prefs: ColumnPreferences.empty()
+      }
+
+      html = render_component(&ColumnPrefs.render/1, assigns)
+
+      [name_row] = Regex.run(~r/<li[^>]*data-field="name"[\s\S]*?<\/li>/, html)
+      [actions_row] = Regex.run(~r/<li[^>]*data-field="actions"[\s\S]*?<\/li>/, html)
+
+      assert name_row =~ ~s(data-reorderable="true")
+      assert name_row =~ "cinder-drag-handle"
+
+      assert actions_row =~ ~s(data-reorderable="false")
+      refute actions_row =~ "cinder-drag-handle"
+    end
+  end
+
+  describe "Cinder.collection — public surface" do
+    test "renders the Edit columns button when column_preferences? is true" do
+      assigns = %{
+        resource: TestUser,
+        actor: nil,
+        id: "users-table",
+        column_preferences?: true,
+        col: [
+          %{field: "name", __slot__: :col},
+          %{field: "email", __slot__: :col}
+        ]
+      }
+
+      html = render_component(&Cinder.Collection.collection/1, assigns)
+
+      assert html =~ "Edit columns"
+      assert html =~ "users-table-column-prefs-hook"
+    end
+
+    test "does not render the button when column_preferences? is false (default)" do
+      assigns = %{
+        resource: TestUser,
+        actor: nil,
+        id: "users-table",
+        col: [
+          %{field: "name", __slot__: :col}
+        ]
+      }
+
+      html = render_component(&Cinder.Collection.collection/1, assigns)
+
+      refute html =~ ~s(phx-click="toggle_column_prefs_drawer")
+      refute html =~ "column-prefs-hook"
+    end
+
+    test "table_wrapper gets `invisible` until prefs are hydrated, then drops it" do
+      assigns = %{
+        resource: TestUser,
+        actor: nil,
+        id: "users-table",
+        column_preferences?: true,
+        col: [%{field: "name", __slot__: :col}]
+      }
+
+      html = render_component(&Cinder.Collection.collection/1, assigns)
+
+      assert html =~ ~r/data-key="table_wrapper_class"[^>]*invisible/ or
+               html =~ ~r/invisible[^"]*"\s+data-key="table_wrapper_class"/
+    end
+
+    test "wrapper has no `invisible` class when prefs are disabled" do
+      assigns = %{
+        resource: TestUser,
+        actor: nil,
+        id: "users-table",
+        col: [%{field: "name", __slot__: :col}]
+      }
+
+      html = render_component(&Cinder.Collection.collection/1, assigns)
+
+      refute html =~ ~r/data-key="table_wrapper_class"[^>]*invisible/
+      refute html =~ ~r/invisible[^"]*"\s+data-key="table_wrapper_class"/
+    end
+
+    test "default_visible: false columns are hidden in the table headers from the start" do
+      assigns = %{
+        resource: TestUser,
+        actor: nil,
+        id: "users-table",
+        column_preferences?: true,
+        col: [
+          %{field: "name", label: "Name", __slot__: :col},
+          %{field: "archived_at", label: "Archived At", default_visible: false, __slot__: :col}
+        ]
+      }
+
+      html = render_component(&Cinder.Collection.collection/1, assigns)
+
+      assert html =~ ~r/<th[^>]*>[\s\S]*?Name[\s\S]*?<\/th>/
+      refute html =~ ~r/<th[^>]*>[\s\S]*?Archived At[\s\S]*?<\/th>/
+      assert html =~ ~r/<li[^>]*data-field="archived_at"/
+    end
+  end
+end

--- a/test/cinder/mix/tasks/cinder_install_test.exs
+++ b/test/cinder/mix/tasks/cinder_install_test.exs
@@ -156,4 +156,64 @@ defmodule Cinder.Mix.Tasks.CinderInstallTest do
       assert String.contains?(v4_path, "cinder")
     end
   end
+
+  describe "inject_into_dependencies/3" do
+    if Code.ensure_loaded?(Igniter) do
+      test "inserts the new dep at the top of the dependencies block" do
+        content = ~s({\n  "name": "demo",\n  "dependencies": {\n    "phoenix": "^1.7"\n  }\n})
+
+        result =
+          Mix.Tasks.Cinder.Install.inject_into_dependencies(
+            content,
+            "cinder",
+            "file:../deps/cinder/assets"
+          )
+
+        assert result =~ ~s("cinder": "file:../deps/cinder/assets",)
+        assert result =~ ~s("phoenix": "^1.7")
+        # New entry must come BEFORE phoenix (alphabetisation isn't enforced;
+        # we just inject at the top to keep the change minimal).
+        cinder_idx = result |> :binary.match(~s("cinder")) |> elem(0)
+        phoenix_idx = result |> :binary.match(~s("phoenix")) |> elem(0)
+        assert cinder_idx < phoenix_idx
+      end
+
+      test "preserves the existing indentation style (2-space)" do
+        content = ~s({\n  "dependencies": {\n    "phoenix": "^1.7"\n  }\n})
+
+        result = Mix.Tasks.Cinder.Install.inject_into_dependencies(content, "cinder", "0.1.0")
+
+        assert result =~ ~s(    "cinder": "0.1.0",)
+      end
+
+      test "preserves the existing indentation style (tab)" do
+        content = "{\n\t\"dependencies\": {\n\t\t\"phoenix\": \"^1.7\"\n\t}\n}"
+
+        result = Mix.Tasks.Cinder.Install.inject_into_dependencies(content, "cinder", "0.1.0")
+
+        assert result =~ "\t\t\"cinder\": \"0.1.0\","
+      end
+
+      test "tolerates whitespace variations in the dependencies opener" do
+        content = ~s({\n  "dependencies":{\n    "phoenix": "^1.7"\n  }\n})
+
+        result = Mix.Tasks.Cinder.Install.inject_into_dependencies(content, "cinder", "0.1.0")
+
+        assert result =~ ~s("cinder": "0.1.0",)
+        assert result =~ ~s("phoenix": "^1.7")
+      end
+
+      test "does not mangle other JSON keys" do
+        content =
+          ~s({\n  "name": "demo",\n  "version": "1.0.0",\n  "dependencies": {\n    "phoenix": "^1.7"\n  }\n})
+
+        result = Mix.Tasks.Cinder.Install.inject_into_dependencies(content, "cinder", "0.1.0")
+
+        assert result =~ ~s("name": "demo")
+        assert result =~ ~s("version": "1.0.0")
+        assert result =~ ~s("phoenix": "^1.7")
+        assert result =~ ~s("cinder": "0.1.0",)
+      end
+    end
+  end
 end

--- a/test/cinder/theme/theme_verification_test.exs
+++ b/test/cinder/theme/theme_verification_test.exs
@@ -37,6 +37,24 @@ defmodule Cinder.ThemeVerificationTest do
     :pagination_current_class
   ]
 
+  @required_column_prefs_properties [
+    :column_prefs_button_class,
+    :column_prefs_panel_class,
+    :column_prefs_backdrop_class,
+    :column_prefs_header_class,
+    :column_prefs_title_class,
+    :column_prefs_close_button_class,
+    :column_prefs_list_class,
+    :column_prefs_item_class,
+    :column_prefs_label_class,
+    :column_prefs_footer_class,
+    :column_prefs_reset_button_class,
+    :column_prefs_done_button_class,
+    :column_prefs_checkbox_class,
+    :column_prefs_drag_handle_class,
+    :column_prefs_pinned_icon_class
+  ]
+
   describe "theme multi-select properties" do
     for theme_module <- @themes do
       test "#{theme_module} has all required multi-select dropdown properties" do
@@ -80,6 +98,27 @@ defmodule Cinder.ThemeVerificationTest do
 
           assert is_binary(theme[property]),
                  "#{unquote(theme_module)} property #{property} should be string, got: #{inspect(theme[property])}"
+        end
+      end
+    end
+  end
+
+  describe "theme column-prefs drawer properties" do
+    for theme_module <- @themes do
+      test "#{theme_module} has all required column-prefs properties as non-empty strings" do
+        theme = unquote(theme_module).resolve_theme()
+
+        for property <- @required_column_prefs_properties do
+          assert Map.has_key?(theme, property),
+                 "#{unquote(theme_module)} missing column-prefs property: #{property}"
+
+          value = theme[property]
+
+          assert is_binary(value),
+                 "#{unquote(theme_module)} property #{property} should be string, got: #{inspect(value)}"
+
+          assert value != "",
+                 "#{unquote(theme_module)} property #{property} should not be empty"
         end
       end
     end


### PR DESCRIPTION
Basically, adds a little 'edit columns' button (final placement TBD)

and a side bar which allows for drag and drop reordering of columns
<img width="310" height="221" alt="Screencast From 2026-05-07 21-27-41" src="https://github.com/user-attachments/assets/4c027554-9e34-4857-b8eb-e1ec65dd88f8" />

Plus the option to lock/unlock or hide/show columns
<img width="152" height="83" alt="Screenshot From 2026-05-07 21-16-45" src="https://github.com/user-attachments/assets/4616b91b-348c-4613-a3eb-a16428c019a4" />




All of which is persisted to the users localStorage