### PR TITLE
Add missing German translation

### DIFF
--- a/i18n/gettext/de/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/de/LC_MESSAGES/cinder.po
@@ -69,7 +69,7 @@ msgstr "Zur Seite %{page}"
 #: lib/cinder/renderers/pagination.ex
 #, elixir-autogen, elixir-format
 msgid "%{total} items"
-msgstr ""
+msgstr "%{total} Einträge"
 
 #: lib/cinder/renderers/pagination.ex
 #, elixir-autogen, elixir-format, fuzzy

--- a/i18n/gettext/de/LC_MESSAGES/cinder.po
+++ b/i18n/gettext/de/LC_MESSAGES/cinder.po
@@ -69,7 +69,7 @@ msgstr "Zur Seite %{page}"
 #: lib/cinder/renderers/pagination.ex
 #, elixir-autogen, elixir-format
 msgid "%{total} items"
-msgstr "%{total} Einträge"
+msgstr "%{total} Elemente"
 
 #: lib/cinder/renderers/pagination.ex
 #, elixir-autogen, elixir-format, fuzzy


### PR DESCRIPTION
Hi @sevenseacat, just a minor addition to the German translations.

A next change could be to use plural form. But I'd need help with most of the other languages for that.