### PR TITLE
feat: add item_class to collections and tables for per-item classes/styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Removed the `sort_asc_icon`, `sort_desc_icon`, and `sort_icon_class` theme properties — list and grid layouts now render the same Heroicon sort indicators as the table (configured via `sort_*_icon_name`/`sort_*_icon_class`). See the [upgrading guide](docs/upgrading.md) for details.
 
+### Features
+
+* Added `item_class` on `<Cinder.collection>` (and `<Cinder.Table.table>`) to set a per-row/item class: a string, or a `fn item -> class end` function evaluated per item, appended to the theme's row/item class.
+
 ### Bugfixes
 
 * `*_nils_first`/`*_nils_last` sort methods now render an icon in list and grid views.

--- a/lib/cinder/collection.ex
+++ b/lib/cinder/collection.ex
@@ -229,6 +229,13 @@ defmodule Cinder.Collection do
     doc: "Function to call when a row/item is clicked. Receives the item as argument."
   )
 
+  attr(:item_class, :any,
+    default: nil,
+    doc:
+      "CSS class(es) for each row/item. A string, or a `fn item -> class end` function " <>
+        "evaluated per item, appended to the theme's row/item class."
+  )
+
   attr(:id_field, :atom,
     default: :id,
     doc: "Field to use as ID for update_if_visible operations (defaults to :id)"
@@ -491,6 +498,7 @@ defmodule Cinder.Collection do
         query_columns={@query_columns}
         row_click={@row_click}
         item_click={@item_click}
+        item_class={@item_class}
         item_slot={@item_slot}
         container_class={@container_class}
         grid_columns={@grid_columns}

--- a/lib/cinder/renderers/grid.ex
+++ b/lib/cinder/renderers/grid.ex
@@ -86,7 +86,7 @@ defmodule Cinder.Renderers.Grid do
         <%= if @has_item_slot do %>
           <div
             :for={item <- @data} :if={not @error}
-            class={get_item_classes_with_selection(@grid_item_class, Map.get(assigns, :selectable, false), Map.get(assigns, :selected_ids, MapSet.new()), item, Map.get(assigns, :id_field, :id), @item_click, @theme)}
+            class={get_item_classes_with_selection(@grid_item_class, Map.get(assigns, :item_class), Map.get(assigns, :selectable, false), Map.get(assigns, :selected_ids, MapSet.new()), item, Map.get(assigns, :id_field, :id), @item_click, @theme)}
             data-key={@grid_item_data_key}
             phx-click={item_click_action(@item_click, Map.get(assigns, :selectable, false), item, Map.get(assigns, :id_field, :id), @myself)}
           >
@@ -229,6 +229,7 @@ defmodule Cinder.Renderers.Grid do
 
   defp get_item_classes_with_selection(
          base_class,
+         user_item_class,
          selectable,
          selected_ids,
          item,
@@ -236,7 +237,8 @@ defmodule Cinder.Renderers.Grid do
          item_click,
          theme
        ) do
-    classes = [base_class]
+    # Merge the per-item user class onto the theme's base item class
+    classes = [base_class, resolve_item_class(user_item_class, item)]
 
     # Add cursor-pointer if item is clickable (either via item_click or selectable without item_click)
     clickable = item_click != nil or (selectable and item_click == nil)

--- a/lib/cinder/renderers/helpers.ex
+++ b/lib/cinder/renderers/helpers.ex
@@ -12,6 +12,16 @@ defmodule Cinder.Renderers.Helpers do
   end
 
   @doc """
+  Resolves a user-supplied row/item class for the given item.
+
+  A `fn item -> class end` function is called with the item; any other value
+  (string, list, or nil) is returned unchanged, to be merged with the theme's
+  base row/item class.
+  """
+  def resolve_item_class(fun, item) when is_function(fun, 1), do: fun.(item)
+  def resolve_item_class(class, _item), do: class
+
+  @doc """
   Builds context map passed to the empty slot via `:let`.
 
   The `filtered?` field is true when any filter has a meaningful value

--- a/lib/cinder/renderers/list.ex
+++ b/lib/cinder/renderers/list.ex
@@ -84,7 +84,7 @@ defmodule Cinder.Renderers.List do
         <%= if @has_item_slot do %>
           <div
             :for={item <- @data} :if={not @error}
-            class={get_item_classes_with_selection(@list_item_class, Map.get(assigns, :selectable, false), Map.get(assigns, :selected_ids, MapSet.new()), item, Map.get(assigns, :id_field, :id), @item_click, @theme)}
+            class={get_item_classes_with_selection(@list_item_class, Map.get(assigns, :item_class), Map.get(assigns, :selectable, false), Map.get(assigns, :selected_ids, MapSet.new()), item, Map.get(assigns, :id_field, :id), @item_click, @theme)}
             data-key={@list_item_data_key}
             phx-click={item_click_action(@item_click, Map.get(assigns, :selectable, false), item, Map.get(assigns, :id_field, :id), @myself)}
           >
@@ -195,6 +195,7 @@ defmodule Cinder.Renderers.List do
 
   defp get_item_classes_with_selection(
          base_class,
+         user_item_class,
          selectable,
          selected_ids,
          item,
@@ -202,7 +203,8 @@ defmodule Cinder.Renderers.List do
          item_click,
          theme
        ) do
-    classes = [base_class]
+    # Merge the per-item user class onto the theme's base item class
+    classes = [base_class, resolve_item_class(user_item_class, item)]
 
     # Add cursor-pointer if item is clickable (either via item_click or selectable without item_click)
     clickable = item_click != nil or (selectable and item_click == nil)

--- a/lib/cinder/renderers/table.ex
+++ b/lib/cinder/renderers/table.ex
@@ -83,7 +83,7 @@ defmodule Cinder.Renderers.Table do
           </thead>
           <tbody class={[@theme.tbody_class, (@loading && "opacity-75" || "")]} data-key="tbody_class">
             <tr :for={item <- @data} :if={not @error}
-                class={get_row_classes(@theme.row_class, @row_click, @selectable, @selected_ids, item, @id_field, @theme)}
+                class={get_row_classes(@theme.row_class, Map.get(assigns, :item_class), @row_click, @selectable, @selected_ids, item, @id_field, @theme)}
                 data-item-id={to_string(Map.get(item, @id_field))}
                 data-key="row_class"
                 phx-click={row_click_action(@row_click, @selectable, item, @id_field, @myself)}>
@@ -161,10 +161,22 @@ defmodule Cinder.Renderers.Table do
   # HELPER FUNCTIONS
   # ============================================================================
 
-  defp get_row_classes(base_classes, row_click, selectable, selected_ids, item, id_field, theme) do
+  defp get_row_classes(
+         base_classes,
+         user_item_class,
+         row_click,
+         selectable,
+         selected_ids,
+         item,
+         id_field,
+         theme
+       ) do
+    # Merge the per-item user class onto the theme's base row class
+    base = [base_classes, resolve_item_class(user_item_class, item)]
+
     # Add cursor-pointer if row is clickable (either via row_click or selectable without row_click)
     clickable = row_click != nil or (selectable and row_click == nil)
-    classes = if clickable, do: [base_classes, "cursor-pointer"], else: [base_classes]
+    classes = if clickable, do: base ++ ["cursor-pointer"], else: base
 
     if selectable and item_selected?(selected_ids, item, id_field) do
       classes ++ [theme.selected_row_class]

--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -69,6 +69,12 @@ defmodule Cinder.Table do
   attr :class, :string, default: "", doc: "Additional CSS classes"
   attr :row_click, :any, default: nil, doc: "Function to call when a row is clicked"
 
+  attr :item_class, :any,
+    default: nil,
+    doc:
+      "CSS class(es) for each row. A string, or a `fn item -> class end` function " <>
+        "evaluated per row, appended to the theme's row class."
+
   slot :col do
     attr :field, :string
     attr :filter, :any

--- a/test/cinder/renderers/item_class_test.exs
+++ b/test/cinder/renderers/item_class_test.exs
@@ -1,0 +1,190 @@
+defmodule Cinder.Renderers.ItemClassTest do
+  @moduledoc """
+  Tests for the `item_class` feature across all renderers.
+  """
+
+  use ExUnit.Case, async: true
+  import Phoenix.LiveViewTest
+
+  alias Cinder.Renderers.Table, as: TableRenderer
+  alias Cinder.Renderers.List, as: ListRenderer
+  alias Cinder.Renderers.Grid, as: GridRenderer
+
+  # Two items that differ on `flagged`, so a per-item function produces two classes.
+  @data [%{id: "1", flagged: true}, %{id: "2", flagged: false}]
+
+  defp flag_class(item), do: if(item.flagged, do: "is-flagged", else: "not-flagged")
+
+  # Each renderer uses the default theme with one identifiable item/row class to assert on.
+  defp table_assigns do
+    col_slot = %{__slot__: :col, field: :name, inner_block: fn _, _item -> "cell" end}
+
+    %{
+      id: "test-table",
+      theme: Cinder.Theme.default() |> Map.put(:row_class, "theme-row"),
+      data: @data,
+      columns: [%{field: :name, label: "Name", sortable: false, class: nil, slot: col_slot}],
+      col_slot: [col_slot],
+      filters: %{},
+      sort_by: [],
+      sort_label: "Sort",
+      loading: false,
+      error: false,
+      loading_message: "Loading...",
+      empty_message: "No results",
+      error_message: "An error occurred",
+      show_filters: false,
+      show_sort: false,
+      show_pagination: false,
+      page: nil,
+      page_size_config: %{},
+      pagination_mode: :offset,
+      myself: nil,
+      filters_label: "Filters",
+      search_term: "",
+      search_enabled: false,
+      search_label: "Search",
+      search_placeholder: "Search...",
+      row_click: nil,
+      selectable: false,
+      selected_ids: MapSet.new(),
+      id_field: :id,
+      bulk_action_slots: []
+    }
+  end
+
+  defp list_assigns do
+    %{
+      id: "test-list",
+      theme: Cinder.Theme.default() |> Map.put(:list_item_class, "theme-item"),
+      data: @data,
+      columns: [],
+      item_slot: [%{__slot__: :item, inner_block: fn _, _ -> "item content" end}],
+      filters: %{},
+      sort_by: [],
+      sort_label: "Sort",
+      loading: false,
+      error: false,
+      loading_message: "Loading...",
+      empty_message: "No results",
+      error_message: "An error occurred",
+      show_filters: false,
+      show_sort: false,
+      show_pagination: false,
+      page: nil,
+      page_size_config: %{},
+      pagination_mode: :offset,
+      myself: nil,
+      container_class: nil,
+      item_click: nil,
+      filters_label: "Filters",
+      search_term: "",
+      search_enabled: false,
+      search_label: "Search",
+      search_placeholder: "Search...",
+      selectable: false,
+      selected_ids: MapSet.new(),
+      id_field: :id,
+      bulk_action_slots: []
+    }
+  end
+
+  defp grid_assigns do
+    list_assigns()
+    |> Map.merge(%{
+      id: "test-grid",
+      theme: Cinder.Theme.default() |> Map.put(:grid_item_class, "theme-item"),
+      grid_columns: [xs: 1]
+    })
+  end
+
+  describe "table item_class" do
+    test "applies a static string to every row, merged with the theme row class" do
+      html =
+        render_component(
+          &TableRenderer.render/1,
+          Map.put(table_assigns(), :item_class, "extra-row")
+        )
+
+      assert html =~ "theme-row"
+      assert html =~ "extra-row"
+    end
+
+    test "evaluates a function per item, merged with the theme row class" do
+      html =
+        render_component(
+          &TableRenderer.render/1,
+          Map.put(table_assigns(), :item_class, &flag_class/1)
+        )
+
+      assert html =~ "is-flagged"
+      assert html =~ "not-flagged"
+      assert html =~ "theme-row"
+    end
+
+    test "is optional and defaults to the theme class only" do
+      html = render_component(&TableRenderer.render/1, table_assigns())
+
+      assert html =~ "theme-row"
+      refute html =~ "is-flagged"
+    end
+
+    test "merges with cursor-pointer and selection classes" do
+      assigns =
+        table_assigns()
+        |> Map.merge(%{
+          item_class: &flag_class/1,
+          selectable: true,
+          selected_ids: MapSet.new(["1"])
+        })
+
+      html = render_component(&TableRenderer.render/1, assigns)
+
+      assert html =~ "is-flagged"
+      assert html =~ "bg-blue-50"
+      assert html =~ "cursor-pointer"
+    end
+  end
+
+  describe "list item_class" do
+    test "evaluates a function per item, merged with the theme item class" do
+      html =
+        render_component(
+          &ListRenderer.render/1,
+          Map.put(list_assigns(), :item_class, &flag_class/1)
+        )
+
+      assert html =~ "is-flagged"
+      assert html =~ "not-flagged"
+      assert html =~ "theme-item"
+    end
+
+    test "is optional" do
+      html = render_component(&ListRenderer.render/1, list_assigns())
+
+      assert html =~ "theme-item"
+      refute html =~ "is-flagged"
+    end
+  end
+
+  describe "grid item_class" do
+    test "evaluates a function per item, merged with the theme item class" do
+      html =
+        render_component(
+          &GridRenderer.render/1,
+          Map.put(grid_assigns(), :item_class, &flag_class/1)
+        )
+
+      assert html =~ "is-flagged"
+      assert html =~ "not-flagged"
+      assert html =~ "theme-item"
+    end
+
+    test "is optional" do
+      html = render_component(&GridRenderer.render/1, grid_assigns())
+
+      assert html =~ "theme-item"
+      refute html =~ "is-flagged"
+    end
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -140,6 +140,7 @@ Filter on fields without displaying them as columns:
 - `page_size={[default: 25, options: [10, 25, 50, 100]]}` - configurable with dropdown
 - `url_state={@url_state}` - enable URL synchronization
 - `click={fn item -> JS.navigate(~p"/path/#{item.id}") end}` - row/item click handler
+- `item_class={fn item -> if item.urgent, do: "bg-red-50" end}` - per-row/item class (string or function), appended to the theme class
 - `query_opts={[timeout: 30_000, load: [:association]]}` - Ash query options
 - `tenant={@tenant}` - multi-tenancy support
 - `scope={@scope}` - Ash scope for authorization context


### PR DESCRIPTION
This PR adds an `item_class` attr on Cinder.collection for per-row/item classes.

Please feel free to make any adjustments or improvements (or to close this entirely)!