### PR TITLE
Add id to filter forms for LiveView form recovery

### DIFF
--- a/lib/cinder/filter_manager.ex
+++ b/lib/cinder/filter_manager.ex
@@ -72,7 +72,7 @@ defmodule Cinder.FilterManager do
 
     ~H"""
     <div :if={@has_content} class={@theme.filter_container_class} data-key="filter_container_class">
-      <form phx-change="filter_change" phx-submit="filter_change" phx-target={@target}>
+      <form id={"#{@table_id}-filters"} phx-change="filter_change" phx-submit="filter_change" phx-target={@target}>
         {render_slot(@controls_slot, @controls_data)}
       </form>
     </div>
@@ -107,7 +107,7 @@ defmodule Cinder.FilterManager do
       />
 
       <div id={"#{@table_id}-filter-body"} class={if(@collapsible and @initially_collapsed, do: "hidden")}>
-        <form phx-change="filter_change" phx-submit="filter_change" phx-target={@target}>
+        <form id={"#{@table_id}-filter-form"} phx-change="filter_change" phx-submit="filter_change" phx-target={@target}>
           <div class={@theme.filter_inputs_class} data-key="filter_inputs_class">
             <Cinder.Controls.render_search
               :if={@controls_data.search != nil}


### PR DESCRIPTION
## Problem

The filter control forms in `Cinder.FilterManager` use `phx-change`/`phx-submit` but have no `id` attribute. LiveView requires form `id`s to perform form recovery following crashes or disconnects.

Apps that enable the strict LiveView test check:

```elixir
config :phoenix_live_view, :test_warnings, missing_form_id: :raise
```

get a runtime error for every Cinder table that renders filters:

> Detected a form with phx-change but missing id

## Fix

Add an `id` derived from the existing `@table_id` assign to both filter forms (the slot-based and default render paths):

- `#{@table_id}-filters` for the controls-slot form
- `#{@table_id}-filter-form` for the default form

## Notes

`@table_id` is already passed into these render functions and used for child element ids (e.g. `#{@table_id}-filter-body`), so the new ids are unique per table.