### PR TITLE
Expose the record count on the on_query_change payload

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -461,15 +461,25 @@ Add `on_query_change` to receive the query in your parent LiveView via `handle_i
 ```
 
 ```elixir
-def handle_info({:query_changed, %{query: query, id: "users-table"}}, socket) do
-  # Store the query for later use (e.g., export)
-  {:noreply, assign(socket, :current_query, query)}
+def handle_info({:query_changed, %{query: query, count: count, id: "users-table"}}, socket) do
+  # Store the query for later use (e.g., export), and the total for display
+  {:noreply, assign(socket, current_query: query, total: count)}
 end
 ```
 
 The callback fires on initial load and whenever filters, sorting, or search change. The received query includes all filters and sorts but no pagination, so you can use it directly for exports.
 
 When you pass a `resource={...}` (or a query without an `action`), Cinder prepares it via `Ash.Query.for_read/4`, so the exposed query has `:scope`, `:actor`, `:tenant`, and scope-supplied `:context` (e.g. timezone) already baked on. The actor lives at the canonical `query.context.private.actor` location. When you pass a pre-prepared `query={Ash.Query.for_read(...)}`, Cinder leaves your auth setup untouched — the exposed query reflects exactly what you handed in, with Cinder's filters/sorts added on top.
+
+### Displaying the total elsewhere
+
+`count` is the total number of matching records — the same number the pagination footer shows. Cinder already asked Ash for it when it loaded the page, so rendering a total outside the collection (in a page header, say) costs no extra query:
+
+```heex
+<h1>Users <span :if={@total}>({@total})</span></h1>
+```
+
+An action without pagination reports the number of records it loaded instead. Any read where the data layer returns no count reports `nil`.
 
 ### Export Example
 

--- a/lib/cinder/collection.ex
+++ b/lib/cinder/collection.ex
@@ -161,7 +161,7 @@ defmodule Cinder.Collection do
     default: nil,
     doc:
       "Event name sent to parent when the query changes. " <>
-        "Parent receives {event_name, %{query: Ash.Query.t(), id: string()}}."
+        "Parent receives {event_name, %{query: Ash.Query.t(), count: integer() | nil, id: string()}}."
   )
 
   attr(:show_pagination, :boolean, default: true, doc: "Whether to show pagination controls")

--- a/lib/cinder/live_component.ex
+++ b/lib/cinder/live_component.ex
@@ -580,11 +580,20 @@ defmodule Cinder.LiveComponent do
 
   defp maybe_notify_query_change(socket, query) do
     if event_name = socket.assigns[:on_query_change] do
-      send(self(), {event_name, %{query: query, id: socket.assigns.id}})
+      payload = %{query: query, count: page_count(socket.assigns[:page]), id: socket.assigns.id}
+      send(self(), {event_name, payload})
     end
 
     socket
   end
+
+  # The count Ash already returned for the page that was just loaded, so parents
+  # can render a total without counting the same filter a second time. nil when
+  # the read did not produce one.
+  defp page_count(%Ash.Page.Offset{count: count}), do: count
+  defp page_count(%Ash.Page.Keyset{count: count}), do: count
+  defp page_count(%{results: results}) when is_list(results), do: length(results)
+  defp page_count(_page), do: nil
 
   # The checkbox is only disabled client-side for non-selectable rows, and the
   # client can send arbitrary ids — re-check against the served page data.

--- a/lib/cinder/table.ex
+++ b/lib/cinder/table.ex
@@ -57,7 +57,7 @@ defmodule Cinder.Table do
     default: nil,
     doc:
       "Event name sent to parent when the query changes. " <>
-        "Parent receives {event_name, %{query: Ash.Query.t(), id: string()}}."
+        "Parent receives {event_name, %{query: Ash.Query.t(), count: integer() | nil, id: string()}}."
 
   attr :show_pagination, :boolean, default: true, doc: "Whether to show pagination controls"
   attr :show_filters, :boolean, default: nil, doc: "Whether to show filter controls"

--- a/test/cinder/query_change_notification_test.exs
+++ b/test/cinder/query_change_notification_test.exs
@@ -1,0 +1,79 @@
+defmodule Cinder.QueryChangeNotificationTest do
+  use ExUnit.Case, async: true
+
+  alias Cinder.LiveComponent
+
+  defp make_socket(assigns) do
+    defaults = %{
+      __changed__: %{},
+      id: "test-table",
+      on_query_change: :query_changed,
+      query: TestUserResource,
+      filters: %{},
+      sort_by: [],
+      current_page: 1,
+      data: [],
+      page: nil,
+      loading: false,
+      error: false
+    }
+
+    %Phoenix.LiveView.Socket{
+      assigns: Map.merge(defaults, assigns),
+      root_pid: self()
+    }
+  end
+
+  defp load(socket, page) do
+    query = Ash.Query.new(TestUserResource)
+    LiveComponent.handle_async(:load_data, {:ok, {{:ok, page}, query}}, socket)
+  end
+
+  describe "on_query_change payload" do
+    test "carries the total count from an offset page" do
+      page = %Ash.Page.Offset{results: [%{id: 1}], count: 42, limit: 25, offset: 0}
+
+      {:noreply, _socket} = load(make_socket(%{}), page)
+
+      assert_received {:query_changed, %{count: 42, id: "test-table"}}
+    end
+
+    test "carries the total count from a keyset page" do
+      page = %Ash.Page.Keyset{results: [%{id: 1}], count: 7, limit: 25}
+
+      {:noreply, _socket} = load(make_socket(%{}), page)
+
+      assert_received {:query_changed, %{count: 7}}
+    end
+
+    test "reports nil when the read returned no count" do
+      page = %Ash.Page.Offset{results: [%{id: 1}], count: nil, limit: 25, offset: 0}
+
+      {:noreply, _socket} = load(make_socket(%{}), page)
+
+      assert_received {:query_changed, %{count: nil}}
+    end
+
+    test "reports the number of loaded records for an unpaginated read" do
+      {:noreply, _socket} = load(make_socket(%{}), %{results: [%{id: 1}, %{id: 2}]})
+
+      assert_received {:query_changed, %{count: 2}}
+    end
+
+    test "still carries the query alongside the count" do
+      page = %Ash.Page.Offset{results: [], count: 0, limit: 25, offset: 0}
+
+      {:noreply, _socket} = load(make_socket(%{}), page)
+
+      assert_received {:query_changed, %{query: %Ash.Query{}, count: 0}}
+    end
+
+    test "sends nothing when on_query_change is not set" do
+      page = %Ash.Page.Offset{results: [], count: 3, limit: 25, offset: 0}
+
+      {:noreply, _socket} = load(make_socket(%{on_query_change: nil}), page)
+
+      refute_received {:query_changed, _payload}
+    end
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -335,6 +335,25 @@ import Cinder.Update
 end)}
 ```
 
+## Query Access
+
+Receive the built query and the total record count in the parent LiveView:
+
+```heex
+<Cinder.collection resource={MyApp.User} actor={@current_user} on_query_change={:query_changed} id="users">
+```
+
+```elixir
+def handle_info({:query_changed, %{query: query, count: count, id: "users"}}, socket) do
+  {:noreply, assign(socket, current_query: query, total: count)}
+end
+```
+
+- Fires on initial load and whenever filters, sorting, or search change
+- `query` has all filters and sorts applied but no pagination - use it directly for exports
+- `count` is the total matching records, the same number the pagination footer shows. Cinder already asked Ash for it, so never run your own `Ash.count!` to display a total
+- `count` is `nil` when the read produced no count; an action without pagination reports the number of records it loaded
+
 ## Custom Filters
 
 ### 1. Configuration


### PR DESCRIPTION
# Expose the record count on the `on_query_change` payload

## Why

A collection knows how many records match the current filters — it renders the
number in its own pagination footer. A parent LiveView cannot get at it. There
is no callback for it, and `page` lives on the LiveComponent's assigns.

So an app that wants to show the total anywhere else — a page header, a summary
line, a tab label — has to count the filter a second time:

```elixir
def handle_info({:query_changed, %{query: query}}, socket) do
  count = query |> Ash.Query.unset([:load, :sort, :limit, :offset]) |> Ash.count!(actor: actor)
  {:noreply, assign(socket, :total, count)}
end
```

That is a full second `COUNT` over the same filter, and it's redundant:
`QueryBuilder.execute/2` already passes `count: true` for both offset
(`query_builder.ex:277`) and keyset (`:295`) pagination, so Ash has computed
the number milliseconds earlier. The parent also has to dedupe the recount
itself, because `on_query_change` fires on paging and sorting too, neither of
which can change a count.

## What

`on_query_change` now sends `count` alongside `query`:

```elixir
{event_name, %{query: query, count: 431, id: "users-table"}}
```

```elixir
def handle_info({:query_changed, %{count: count, id: "users-table"}}, socket) do
  {:noreply, assign(socket, :total, count)}
end
```

The value is read off the page that was just loaded, so it costs nothing and
always agrees with the pagination footer — it lands in the same render as the
rows, with no second query and nothing for the parent to dedupe.

- `%Ash.Page.Offset{}` / `%Ash.Page.Keyset{}` → the count Ash returned, which
  may be `nil` if the read produced none. This keeps working if counting ever
  becomes opt-out, as suggested in #154.
- An unpaginated read (`execute_without_pagination/2` returns `%{results: ...}`)
  → `length(results)`, which is the true total in that case since every matching
  record was loaded.
- Anything else → `nil`.

## Compatibility

Additive. The payload is a map, and existing handlers match on `query` and `id`,
so a new key breaks no consumer. Documented on both `<Cinder.collection>` and
`<Cinder.Table.table>`.

## Docs

`docs/advanced.md` gains a short "Displaying the total elsewhere" subsection.

`usage-rules.md` had no `on_query_change` entry at all, so this adds a "Query
Access" section covering the callback and the count. That is the file coding
agents read, and its silence here is what leads to generated code that runs a
second `Ash.count!` over a query Cinder has already counted — which is exactly
the code this change removes. Happy to drop that hunk if you would rather keep
the PR to the payload alone.

No CHANGELOG entry — the Unreleased entries look maintainer-curated, with
attribution and PR links. Say the word and I will add one in whatever form you
prefer.

## Tests

`test/cinder/query_change_notification_test.exs` covers the offset, keyset,
`nil`-count, and unpaginated cases, that the query is still delivered alongside
the count, and that nothing is sent when `on_query_change` is unset. Five of the
six fail without the change. Full suite green (1493 tests, 6 doctests).
